### PR TITLE
Added ability to listen to Multicast IPs

### DIFF
--- a/VL.IO.OSC.vl
+++ b/VL.IO.OSC.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="Bx9aFHFOZjuOHfIbMh6cIZ" LanguageVersion="2021.4.9.982" Version="0.128">
-  <NugetDependency Id="PBCBJCsT0oYNNATDI2tfdx" Location="VL.CoreLib" Version="2021.4.9" />
+<Document xmlns:p="property" Id="Bx9aFHFOZjuOHfIbMh6cIZ" LanguageVersion="2021.4.12.1374" Version="0.128">
+  <NugetDependency Id="PBCBJCsT0oYNNATDI2tfdx" Location="VL.CoreLib" Version="2021.4.12" />
   <Patch Id="FYxfk4baLHQOy21wbW1N8g">
     <Canvas Id="DOx0V0uYW6CLW195bWBBzA" DefaultCategory="IO.OSC" CanvasType="FullCategory">
       <!--
@@ -232,6 +232,10 @@
                             <FullNameCategoryReference ID="Primitive" />
                           </p:NodeReference>
                           <Pin Id="EOqXxibAgS3ODrL3XNZw7Q" Name="Condition" Kind="InputPin" />
+                          <ControlPoint Id="Rad3Zp5XiyxOX4ZtZBM5f1" Bounds="402,1939" Alignment="Top" />
+                          <ControlPoint Id="GUHCfh9XLeiO9IFTwtruTq" Bounds="404,2039" Alignment="Bottom" />
+                          <ControlPoint Id="JPr42HByn34MV5ziwunut4" Bounds="592,1939" Alignment="Top" />
+                          <ControlPoint Id="Rcq3iigNmNvLG38WQg68x4" Bounds="591,2039" Alignment="Bottom" />
                           <Patch Id="DZdwHmkEMk6Qal62xUj90r" ManuallySortedPins="true">
                             <Patch Id="BuHi3PPO3ALQYkchiFYRJP" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="IY9MTkAKOt6Pkf7nkN9GsA" Name="Then" ManuallySortedPins="true" />
@@ -254,10 +258,6 @@
                               <Pin Id="Q7nEmcZVAqvPnR4wFksv9S" Name="Output" Kind="StateOutputPin" />
                             </Node>
                           </Patch>
-                          <ControlPoint Id="Rad3Zp5XiyxOX4ZtZBM5f1" Bounds="402,1939" Alignment="Top" />
-                          <ControlPoint Id="GUHCfh9XLeiO9IFTwtruTq" Bounds="404,2039" Alignment="Bottom" />
-                          <ControlPoint Id="JPr42HByn34MV5ziwunut4" Bounds="592,1939" Alignment="Top" />
-                          <ControlPoint Id="Rcq3iigNmNvLG38WQg68x4" Bounds="591,2039" Alignment="Bottom" />
                         </Node>
                         <Node Bounds="402,2083,66,26" Id="Lrg9gCNc5ZoPpwDSqjfF8F">
                           <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
@@ -913,27 +913,6 @@
             </Node>
             <Pad Id="IapAH03Y0GTMndBiJfEWeh" Bounds="870,520" />
           </Canvas>
-          <Patch Id="LQDhm8l8hswOi3TdetvBNs" Name="Create (Internal)" ParticipatingElements="IST5RNegAyyLVTkZIyA34x,NHaPJlT7dWHLAOOioXUpF5" />
-          <Patch Id="CAw4X3LIAUdNnaE42FLkgm" Name="Update (Internal)" ManuallySortedPins="true">
-            <Pin Id="LcwJPFidbUzNbLUQCOfpSB" Name="Server" Kind="InputPin" DefaultValue="127.0.0.1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="JdrAhx92cbSNIn4VmgbE63" Name="Port" Kind="InputPin" DefaultValue="4444">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="HeyRNQLIifPPZfL88RhJ3l" Name="Maximum Bundle Size" Kind="InputPin" DefaultValue="1024">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="FogAGIgJqWQPPZQvMB9wuT" Name="Is Open" Kind="OutputPin" />
-            <Pin Id="OMCa5bSAuS0LAoLaC3lPQe" Name="Bundle Size Exceeded" Kind="OutputPin" Bounds="856,1347" />
-            <Pin Id="G2euMtUKW0JOhYDNJIwkaZ" Name="Enabled" Kind="InputPin" />
-          </Patch>
           <ProcessDefinition Id="G5seSauStMYLs35PSzf3h2" HasStateOut="true">
             <Fragment Id="QJiKWEnP5SXMB7P1KOO1zG" Patch="LQDhm8l8hswOi3TdetvBNs" Enabled="true" />
             <Fragment Id="Jv9fvODfMvDOA6VQJjYog7" Patch="CAw4X3LIAUdNnaE42FLkgm" Enabled="true" />
@@ -951,16 +930,6 @@
           <Link Id="Cv5IMMyLWPENOLCx9Atabu" Ids="PLfKPFMvuI4LMgFBh4sxOc,JdxCEWsG1TGNW8gsqQNfUK" />
           <Link Id="DNCtcoglxAtPpItdArlq1j" Ids="G2euMtUKW0JOhYDNJIwkaZ,PLfKPFMvuI4LMgFBh4sxOc" IsHidden="true" />
           <Link Id="PZVni9JxajBQcOyga36UVm" Ids="RvXGhEVKAOdPKWbObF902X,QX7pfC3UelPMrsE7gbamkD" />
-          <Patch Id="MbcYJCiph5YOzCKxkWXjks" Name="SendMessage" ManuallySortedPins="true">
-            <Pin Id="G5OBDnvwQqOLbCcdS6shsk" Name="Address" Kind="InputPin" />
-            <Pin Id="HFWr0A6uxDbMyjE5xjXMrk" Name="Arguments" Kind="InputPin" />
-            <Pin Id="C9DpmWVJkBqMHXDbN5mOwH" Name="Bundled Per Frame" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="MLIpJ4Lcip9LV9EMfh1SQt" Name="Apply" Kind="InputPin" Bounds="217,796" />
-          </Patch>
           <Link Id="LC6WlXQJTDmL5y2YMVOCQp" Ids="LcwJPFidbUzNbLUQCOfpSB,NOcaMxreZiMOxfl5mxiQAt" IsHidden="true" />
           <Link Id="RrHkCl2qBmgOf2Bgygc98q" Ids="JdrAhx92cbSNIn4VmgbE63,MdNCKEaHpVnPTUnTE1XvPG" IsHidden="true" />
           <Link Id="Q0CeHsu3Bs7PfrZQl2szjN" Ids="JZndBoyNkujQBxO61I8e1I,Iq8dvFYRfNHLX5vvxi15Hd" />
@@ -1001,16 +970,6 @@
           <Link Id="Hj01g1YlinbMfeVQtbA71J" Ids="DrT3OnJo0UzNUADECBUZuq,CY2etvlOkWpMjOjtCEYE7o" />
           <Link Id="EaGIrGFF5NUP9lJ5L4WRVj" Ids="QtdWEP8GG79NUSJ1QNcH6D,FBC23f9Su7rLKDdJWpgpYM" />
           <Link Id="C53n5JTJspeM1QFHWJTjVe" Ids="Nt7ZECpKNCbMzCq3uek0rC,U6mvNbED3owMSNIWd1oaWF" />
-          <Patch Id="I5bDbfrCMEfQNKe6rBDRoX" Name="SendBundle" ManuallySortedPins="true">
-            <Pin Id="UVR1GzRanPkLh6ko0WHXbV" Name="Input" Kind="InputPin" />
-            <Pin Id="DuOYEmn7ggqQGJa8wGMocx" Name="Maximum Bundle Size" Kind="InputPin" />
-            <Pin Id="ThtZypsbLuzNR0phPGzShh" Name="Apply" Kind="InputPin" Bounds="973,349" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="CevHaeHqlV5PgFcJotRKbT" Name="Bundle Size Exceeded" Kind="OutputPin" />
-          </Patch>
           <Link Id="Ca10BZZcGaZPvEiszq1qx9" Ids="BC1D1wDoOJtNsdFTuKlbbZ,K3xlhzZOSnVObqGnjSp3T7" />
           <Link Id="QabubYr2cVGNdMCo6U72z6" Ids="UVR1GzRanPkLh6ko0WHXbV,BC1D1wDoOJtNsdFTuKlbbZ" IsHidden="true" />
           <Link Id="LtwPLSwisjmNBjEbwECsjs" Ids="VCX0KsATJ0qQKRhiYYNLQ4,CevHaeHqlV5PgFcJotRKbT" IsHidden="true" />
@@ -1023,7 +982,6 @@
           <Link Id="KJLPGMpMmxbLlzhaUqk0xQ" Ids="TiwhDmGrDLLOywVIbQXrIR,FlbwCKgPuDPPtM7lTSgz6J" />
           <Link Id="T6mR85cswX7MbNFZGJcJKs" Ids="JVjpzsAGtELPi8V6vLTxDY,UW5Hr0YR0HTMUEhtna6sXT" />
           <Link Id="TNPcQeybWimPjRN4T3Tc0u" Ids="Iq8dvFYRfNHLX5vvxi15Hd,JFYRtynkxf5LMLEFXrbXNF" />
-          <Patch Id="ThdCNu3LEbXL6zvQeKpzF5" Name="Dispose (Internal)" />
           <Slot Id="NKnJOk9tMh3PwttUsBts0t" Name="CurrentEntry" />
           <Link Id="UEAG1Yb3HUdOBhNq2hNoIM" Ids="BVXW9RvNvUHPO0Cqj3OU72,FtOuX4YBnOXL69RkFFDaCL" IsFeedback="true" />
           <Link Id="EzVNZaSTV1RMiWqGgigSF1" Ids="BVXW9RvNvUHPO0Cqj3OU72,QDauXInHCmUMfAv8Mgc2GQ" />
@@ -1041,15 +999,6 @@
           <Link Id="BS4YFd2pLvEPBGwBd6TwhB" Ids="Tkp9mTmzPjnOlx1XlLCck7,ISTrdR9I2Z1NVW5VPDJEtN" />
           <Link Id="UJWm2WOFqhqQE9SGvOdPIz" Ids="Cet082KsSe0L9vu950dL0O,KvxA0wQF7nXM2dmCVrKtqR" />
           <Link Id="PcEoY4lGwFyPpAnYu716fO" Ids="VCySKPT1pCGOeQ3nvO5lyI,GPCqbpEQxp8Mys5BJRUV5g" />
-          <Patch Id="KrZhaurhIJTQSjudAsVN16" Name="SendMessage (Empty)" ManuallySortedPins="true">
-            <Pin Id="Ul4MOgI0DoyOC3h1WPUmzy" Name="Address" Kind="InputPin" />
-            <Pin Id="J9Aqeo3IgdLLL4VTzsXTDf" Name="Bundled Per Frame" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="Me64B6sxpaZPU5uizjQQxE" Name="Apply" Kind="InputPin" Bounds="-394,725" />
-          </Patch>
           <Link Id="VrrDjraRByvMlqnWwLF1A9" Ids="Ul4MOgI0DoyOC3h1WPUmzy,Cet082KsSe0L9vu950dL0O" IsHidden="true" />
           <Link Id="GRPHRwB0PxCLOkpGnzGz9Z" Ids="LcwJPFidbUzNbLUQCOfpSB,PjRuUfDmMIIOTExmkgGboL" IsHidden="true" />
           <Link Id="OuOpEM0IlbxM77ZtoBBxGv" Ids="JdrAhx92cbSNIn4VmgbE63,KDgvxWq9x5CP5aNH6GGhct" IsHidden="true" />
@@ -1083,6 +1032,57 @@
           <Link Id="MBjHwELahQHQRMm3Jie7HI" Ids="NO26EnW1GaMM7lBEgdrsJ5,Co4rhUazvyiPksqViNDTlt" />
           <Link Id="BpqBvzPrKn7OrW1j12PpGB" Ids="NO26EnW1GaMM7lBEgdrsJ5,IapAH03Y0GTMndBiJfEWeh" />
           <Link Id="Nj36TZT8031MlJb7Hl4kD2" Ids="IapAH03Y0GTMndBiJfEWeh,LGDCDm9OxhgQbsFaq5Jatj" />
+          <Patch Id="LQDhm8l8hswOi3TdetvBNs" Name="Create (Internal)" ParticipatingElements="IST5RNegAyyLVTkZIyA34x,NHaPJlT7dWHLAOOioXUpF5" />
+          <Patch Id="CAw4X3LIAUdNnaE42FLkgm" Name="Update (Internal)" ManuallySortedPins="true">
+            <Pin Id="LcwJPFidbUzNbLUQCOfpSB" Name="Server" Kind="InputPin" DefaultValue="127.0.0.1">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="JdrAhx92cbSNIn4VmgbE63" Name="Port" Kind="InputPin" DefaultValue="4444">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="HeyRNQLIifPPZfL88RhJ3l" Name="Maximum Bundle Size" Kind="InputPin" DefaultValue="1024">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="G2euMtUKW0JOhYDNJIwkaZ" Name="Enabled" Kind="InputPin" />
+            <Pin Id="FogAGIgJqWQPPZQvMB9wuT" Name="Is Open" Kind="OutputPin" />
+            <Pin Id="OMCa5bSAuS0LAoLaC3lPQe" Name="Bundle Size Exceeded" Kind="OutputPin" Bounds="856,1347" />
+          </Patch>
+          <Patch Id="MbcYJCiph5YOzCKxkWXjks" Name="SendMessage" ManuallySortedPins="true">
+            <Pin Id="G5OBDnvwQqOLbCcdS6shsk" Name="Address" Kind="InputPin" />
+            <Pin Id="HFWr0A6uxDbMyjE5xjXMrk" Name="Arguments" Kind="InputPin" />
+            <Pin Id="C9DpmWVJkBqMHXDbN5mOwH" Name="Bundled Per Frame" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="MLIpJ4Lcip9LV9EMfh1SQt" Name="Apply" Kind="InputPin" Bounds="217,796" />
+          </Patch>
+          <Patch Id="I5bDbfrCMEfQNKe6rBDRoX" Name="SendBundle" ManuallySortedPins="true">
+            <Pin Id="UVR1GzRanPkLh6ko0WHXbV" Name="Input" Kind="InputPin" />
+            <Pin Id="DuOYEmn7ggqQGJa8wGMocx" Name="Maximum Bundle Size" Kind="InputPin" />
+            <Pin Id="ThtZypsbLuzNR0phPGzShh" Name="Apply" Kind="InputPin" Bounds="973,349" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="CevHaeHqlV5PgFcJotRKbT" Name="Bundle Size Exceeded" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="ThdCNu3LEbXL6zvQeKpzF5" Name="Dispose (Internal)" />
+          <Patch Id="KrZhaurhIJTQSjudAsVN16" Name="SendMessage (Empty)" ManuallySortedPins="true">
+            <Pin Id="Ul4MOgI0DoyOC3h1WPUmzy" Name="Address" Kind="InputPin" />
+            <Pin Id="J9Aqeo3IgdLLL4VTzsXTDf" Name="Bundled Per Frame" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="Me64B6sxpaZPU5uizjQQxE" Name="Apply" Kind="InputPin" Bounds="-394,725" />
+          </Patch>
         </Patch>
       </Node>
       <!--
@@ -1104,6 +1104,7 @@
               </p:NodeReference>
               <Pin Id="V3Yg9CQUjy9NoEuG1UMW8f" Name="Local Address" Kind="InputPin" />
               <Pin Id="OUKFJ9iuahYMx2zFZYRY5g" Name="Local Port" Kind="InputPin" />
+              <Pin Id="BZ6bOI7mpM8LUwN7AVMUsZ" Name="Multicast Address" Kind="InputPin" />
               <Pin Id="E3N2zvSmw0lN57bPiD49EP" Name="Enabled" Kind="InputPin" />
               <Pin Id="LI3vr5btx2LMH5NdGdkb1C" Name="Datagrams" Kind="OutputPin" />
               <Pin Id="Us7OQ22VvnbQJbD6g0suI0" Name="Is Open" Kind="OutputPin" />
@@ -1116,7 +1117,7 @@
               <Pin Id="EyGsKPlMfE8Lo67SywVPo7" Name="Input" Kind="InputPin" />
               <Pin Id="McD0rxChkpRLOYuk7MplTj" Name="Result" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="D194eFIpaTxLntHnVFzUNp" Bounds="348,85" />
+            <ControlPoint Id="D194eFIpaTxLntHnVFzUNp" Bounds="354,-102" />
             <ControlPoint Id="BCfKr0FAjAmNdA5kaC55Xd" Bounds="443,85" />
             <ControlPoint Id="SEUIGacq9XOMfaEz2wRBbA" Bounds="507,85" />
             <ControlPoint Id="OteLumLIkpbMYD7BtxsvPt" Bounds="414,176" />
@@ -1140,6 +1141,8 @@
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:NodeReference>
               <Pin Id="IxclsB3L41TMavCRK6zGq5" Name="Condition" Kind="InputPin" />
+              <ControlPoint Id="A6ONwD8W82SL47Yje7lagQ" Bounds="444,1124" Alignment="Bottom" />
+              <ControlPoint Id="T2domR7aeKmNXpWUjBxNz8" Bounds="404,600" Alignment="Top" />
               <Patch Id="FvlYqnkJK72MRp91kHFNiL" ManuallySortedPins="true">
                 <Patch Id="IdVf5s2C3omNHrG4VhecjD" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="H9k5r0droSbQambIFa8Q1m" Name="Then" ManuallySortedPins="true" />
@@ -1160,6 +1163,8 @@
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:NodeReference>
                   <Pin Id="RzxwxmxO9uKOQxmnrawTTQ" Name="Break" Kind="OutputPin" />
+                  <ControlPoint Id="IVY4pghs3WqLljmp0ikQSH" Bounds="478,784" Alignment="Top" />
+                  <ControlPoint Id="Srj2Rvibel2Mjb8ajpM60S" Bounds="444,1104" Alignment="Bottom" />
                   <Patch Id="QPiMQZUizacOerMbt9Ik9D" ManuallySortedPins="true">
                     <Patch Id="HdGobmiDs4CNYfiaoeK3hD" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="HBMhqqi3krhOxp80VAEtQ8" Name="Update" ManuallySortedPins="true" />
@@ -1183,6 +1188,10 @@
                         <CategoryReference Kind="Category" Name="Primitive" />
                       </p:NodeReference>
                       <Pin Id="TGLOx1wKX0FNoNzOCaRnR8" Name="Condition" Kind="InputPin" />
+                      <ControlPoint Id="QpMZYZHM41nPJcggI1Fz8X" Bounds="511,1022" Alignment="Bottom" />
+                      <ControlPoint Id="TJL8pp7BGBxONCcmGLPmzi" Bounds="483,880" Alignment="Top" />
+                      <ControlPoint Id="SXvu9uyflhKNLfyLqxXrRA" Bounds="563,1022" Alignment="Bottom" />
+                      <ControlPoint Id="QWaZG7DvdGIPeex78SiLv7" Bounds="544,880" Alignment="Top" />
                       <Patch Id="BnhzLuwEmFbMycZzatZQqA" ManuallySortedPins="true">
                         <Patch Id="SU5Y6L9tttmMTQzOGCA0ay" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="V2kVS9wWMq4MkqI98JlSXf" Name="Then" ManuallySortedPins="true" />
@@ -1226,10 +1235,6 @@
                           <Pin Id="IsiuIF0rLcILLyFJzPB15B" Name="Result" Kind="OutputPin" />
                         </Node>
                       </Patch>
-                      <ControlPoint Id="QpMZYZHM41nPJcggI1Fz8X" Bounds="511,1022" Alignment="Bottom" />
-                      <ControlPoint Id="TJL8pp7BGBxONCcmGLPmzi" Bounds="483,880" Alignment="Top" />
-                      <ControlPoint Id="SXvu9uyflhKNLfyLqxXrRA" Bounds="563,1022" Alignment="Bottom" />
-                      <ControlPoint Id="QWaZG7DvdGIPeex78SiLv7" Bounds="544,880" Alignment="Top" />
                     </Node>
                     <Node Bounds="442,1055,45,19" Id="CUzglKk15gFN4JU59WRzsr">
                       <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
@@ -1243,8 +1248,6 @@
                       <Pin Id="FsU95wtTdYELm3uOZ0dRFS" Name="Input 3" Kind="InputPin" />
                     </Node>
                   </Patch>
-                  <ControlPoint Id="IVY4pghs3WqLljmp0ikQSH" Bounds="478,784" Alignment="Top" />
-                  <ControlPoint Id="Srj2Rvibel2Mjb8ajpM60S" Bounds="444,1104" Alignment="Bottom" />
                 </Node>
                 <Node Bounds="475,731,41,26" Id="RMKbVUKDKiVO8oTeZkFCw0">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
@@ -1282,6 +1285,10 @@
                     <FullNameCategoryReference ID="Primitive" />
                   </p:NodeReference>
                   <Pin Id="JPKxoNzajSZP8i7KjjXtzs" Name="Condition" Kind="InputPin" />
+                  <ControlPoint Id="Uea1bJz9yVIN9jO1KsRam9" Bounds="423,613" Alignment="Bottom" />
+                  <ControlPoint Id="FCvp9wgF3swO6dvSlduiso" Bounds="544,387" Alignment="Top" />
+                  <ControlPoint Id="MXLfyMnU8hJOQ6DcEtmBIK" Bounds="456,613" Alignment="Bottom" />
+                  <ControlPoint Id="DpsFfKAsrpMNQfce1pE8bM" Bounds="577,387" Alignment="Top" />
                   <Patch Id="MeSPWDiQCdAOxsptVZWbOY" ManuallySortedPins="true">
                     <Patch Id="AQHyiWJLuS6NW6cDN3AgBN" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="UqmHG1fxx4kNf7X5zBrbve" Name="Then" ManuallySortedPins="true" />
@@ -1293,6 +1300,8 @@
                       </p:NodeReference>
                       <Pin Id="OdBaPo24mV2NecmsJe4qXP" Name="Break" Kind="OutputPin" />
                       <ControlPoint Id="UhzMqhwnJEGOEq4ZFAthvN" Bounds="397,454" Alignment="Top" />
+                      <ControlPoint Id="DqSHOtilPoLMW4RycwI9Xe" Bounds="424,454" Alignment="Top" />
+                      <ControlPoint Id="Hw90uzKmtAAOG0wOWTQDAK" Bounds="425,581" Alignment="Bottom" />
                       <Patch Id="OzP13jTwAXoM35XFk8Mtin" ManuallySortedPins="true">
                         <Patch Id="Dhw6uNgjdxwLi7X7tZfs7a" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="SMEdAdS7s3XO9h7zchH1mu" Name="Update" ManuallySortedPins="true" />
@@ -1330,8 +1339,6 @@
                           <Pin Id="ObBh0EzUnp0QJtXmeeePbt" Name="Arguments" Kind="OutputPin" />
                         </Node>
                       </Patch>
-                      <ControlPoint Id="DqSHOtilPoLMW4RycwI9Xe" Bounds="424,454" Alignment="Top" />
-                      <ControlPoint Id="Hw90uzKmtAAOG0wOWTQDAK" Bounds="425,581" Alignment="Bottom" />
                     </Node>
                     <Node Bounds="395,404,47,19" Id="TCcptjWaTENQDBrPopOcEL">
                       <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
@@ -1342,10 +1349,6 @@
                       <Pin Id="GQ0zuhwp2HmLjY82YnFGAq" Name="Output" Kind="StateOutputPin" />
                     </Node>
                   </Patch>
-                  <ControlPoint Id="Uea1bJz9yVIN9jO1KsRam9" Bounds="423,613" Alignment="Bottom" />
-                  <ControlPoint Id="FCvp9wgF3swO6dvSlduiso" Bounds="544,387" Alignment="Top" />
-                  <ControlPoint Id="MXLfyMnU8hJOQ6DcEtmBIK" Bounds="456,613" Alignment="Bottom" />
-                  <ControlPoint Id="DpsFfKAsrpMNQfce1pE8bM" Bounds="577,387" Alignment="Top" />
                 </Node>
                 <Node Bounds="544,330,81,26" Id="PLS6TO76GNxNMhnBSfCz2d">
                   <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastSymbolSource="VL.Collections.vl">
@@ -1358,59 +1361,95 @@
                   <Pin Id="UyOm3NQJHR8MnjrZDy9p5T" Name="Apply" Kind="InputPin" />
                 </Node>
               </Patch>
-              <ControlPoint Id="A6ONwD8W82SL47Yje7lagQ" Bounds="444,1124" Alignment="Bottom" />
-              <ControlPoint Id="T2domR7aeKmNXpWUjBxNz8" Bounds="404,600" Alignment="Top" />
             </Node>
             <ControlPoint Id="Ewzj4L0E9U6OYAXMS2ezDh" Bounds="703,600" />
-          </Canvas>
-          <Patch Id="TuOkxV9syBxPwRTvVZB6JZ" Name="Create" />
-          <Patch Id="NPwec6eTeoYO8uqHWVKkZr" Name="Update" ManuallySortedPins="true">
-            <Pin Id="KFcV8Y1t85lMBfH2z1jXIF" Name="Listening IP" Kind="InputPin" Bounds="546,285" />
-            <Pin Id="OfPiFZFtU1bQGlGqp3AQzo" Name="Port" Kind="InputPin" Bounds="669,279" DefaultValue="4444">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Integer32" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="HWExlgqRXt1MKcqPYDVUCr" Name="Enable Data Preview" Kind="InputPin" Bounds="500,278" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="BW1aqDkFEILONSETbCIoaF" Name="Sort Data Preview" Kind="InputPin" Bounds="703,599" />
-            <Pin Id="MFV8Jj2EI1zMJQS5GVv3pQ" Name="Reset Data Preview" Kind="InputPin" Bounds="787,388" DefaultValue="False">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="OJlbgMSVvlgNdJeNIRtcpd" Name="Enabled" Kind="InputPin" Bounds="900,293" />
-            <Pin Id="LmJ7kikouupOoTBg8xiYF9" Name="Data" Kind="OutputPin" Bounds="741,310" />
-            <Pin Id="PsyNzSRWz6LM2vjdHCA4y5" Name="Data Preview" Kind="OutputPin">
+            <Node Bounds="303,-88,45,19" Id="AAXhpA1eDljMBcjjqjRusi">
+              <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Split (String)" />
+              </p:NodeReference>
+              <Pin Id="RZ6nTtNAwQ8On0V7ZcenOJ" Name="Input" Kind="StateInputPin" />
+              <Pin Id="E9ztDNfuakBM7t1POIYEki" Name="Separator" Kind="InputPin" DefaultValue="." />
+              <Pin Id="LPziGEfQE9HNedUVYwRp6N" Name="Options" Kind="InputPin" />
+              <Pin Id="J8aZnWHx591NZ4zbZ6CLNv" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="303,-59,41,26" Id="TIqyl1p53lPOlApAswkaUx">
+              <p:NodeReference LastCategoryFullName="VL.Lib.Collections.Spread" LastSymbolSource="VL.Core.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="Spread" NeedsToBeDirectParent="true" />
+                <Choice Kind="OperationCallFlag" Name="First" />
+              </p:NodeReference>
+              <Pin Id="TOeIUe7AQMoLhbCOBe7uqv" Name="Input" Kind="StateInputPin" />
+              <Pin Id="SawQaa3S6qbLeCMoyza30H" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="265,-24,55,19" Id="JaVCQXtsCXWOU92tcYGHme">
+              <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="TryParse" />
+              </p:NodeReference>
+              <Pin Id="F3qOUBvEhZFMYJWjfJjoVA" Name="String" Kind="InputPin" />
+              <Pin Id="N2lQ5bKtEZOPMds4nF3kaI" Name="Value" Kind="OutputPin" />
+              <Pin Id="CipbFrhHbjpLWwDAUk43Ss" Name="Success" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="233,20,31,19" Id="MUV0qLKDcExO6Afx88BP9N">
+              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="&lt;=" />
+              </p:NodeReference>
+              <Pin Id="SVnKISeDInoQKM2gmodVdE" Name="Input" Kind="InputPin" />
+              <Pin Id="FXJeTatbaq8M6Ksz95Nonm" Name="Input 2" Kind="InputPin" />
+              <Pin Id="ILQdnZ67z4IQBpfVRwdVp7" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="271,19,31,19" Id="VelRAA2DbhQLMrRuJfzrYF">
+              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="&lt;=" />
+              </p:NodeReference>
+              <Pin Id="B54ifXlmTEGQMLNC3GsIDi" Name="Input" Kind="InputPin" />
+              <Pin Id="Rs5hfOJ9V89P4Je9ji4s3N" Name="Input 2" Kind="InputPin" />
+              <Pin Id="CWMzOV4bXL9NZRVTlPMDne" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Pad Id="Qxvu5h0z7v3QT1yEtY2cZ6" Bounds="204,3,35,15" ShowValueBox="true" isIOBox="true" Value="224">
               <p:TypeAnnotation>
-                <Choice Kind="TypeFlag" Name="Spread" />
-                <p:TypeArguments>
-                  <TypeReference>
-                    <Choice Kind="TypeFlag" Name="Spread" />
-                    <p:TypeArguments>
-                      <TypeReference>
-                        <Choice Kind="TypeFlag" Name="String" />
-                      </TypeReference>
-                    </p:TypeArguments>
-                  </TypeReference>
-                </p:TypeArguments>
+                <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
+                <CategoryReference Kind="Category" Name="Primitive" />
               </p:TypeAnnotation>
-            </Pin>
-            <Pin Id="Gph0Y88wPqZMJjqgLqAnK6" Name="Is Open" Kind="OutputPin" Bounds="834,381" />
-          </Patch>
+            </Pad>
+            <Pad Id="Tew9Bi8xHB9Qbne09BXUpm" Bounds="299,5,35,15" ShowValueBox="true" isIOBox="true" Value="239">
+              <p:TypeAnnotation>
+                <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="233,52,43,19" Id="AmozmPGHg3zNUeKfiJSjL8">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="AND" />
+              </p:NodeReference>
+              <Pin Id="E3Dx6S3dz6gP4ruiqMMygT" Name="Input" Kind="StateInputPin" />
+              <Pin Id="GJPVH3NtCKFPh6tqixHuqh" Name="Input 2" Kind="InputPin" />
+              <Pin Id="C2OR3i0ZA09P4KKBX6eTyC" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="316,79,77,19" Id="HvFAniANGlpNZq5cML5Uiq">
+              <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SwitchOutput" />
+              </p:NodeReference>
+              <Pin Id="JL7c2AGaqGiMSBPfJ72zvD" Name="Condition" Kind="InputPin" />
+              <Pin Id="JHqbUzxGsXNNAHDu4sk4HL" Name="Input" Kind="InputPin" />
+              <Pin Id="ILoQd4g4IGxMZJbsemSZll" Name="Default" Kind="InputPin" DefaultValue="0.0.0.0" />
+              <Pin Id="RuDm93rPkNAOLblVLOwmQx" Name="True" Kind="OutputPin" />
+              <Pin Id="Mj73JmmQokTQaC7V1tfqnJ" Name="False" Kind="OutputPin" />
+            </Node>
+          </Canvas>
           <ProcessDefinition Id="IZO13dCXPUzQKfkMuhxPZn">
             <Fragment Id="JVTR4VSui6rNQlPJS9W27R" Patch="TuOkxV9syBxPwRTvVZB6JZ" Enabled="true" />
             <Fragment Id="LYH4jfXLz34QZdAG5FVm7s" Patch="NPwec6eTeoYO8uqHWVKkZr" Enabled="true" />
           </ProcessDefinition>
           <Link Id="BMHOUJmbpiGPEpNKDIh0uD" Ids="LI3vr5btx2LMH5NdGdkb1C,EyGsKPlMfE8Lo67SywVPo7" />
-          <Link Id="KnU0PbACtNYO1VW3IUoGtc" Ids="D194eFIpaTxLntHnVFzUNp,V3Yg9CQUjy9NoEuG1UMW8f" />
           <Link Id="CACdD9L5CLUN7IPNVnYKQq" Ids="KFcV8Y1t85lMBfH2z1jXIF,D194eFIpaTxLntHnVFzUNp" IsHidden="true" />
           <Link Id="Rl5doZl5EFdMo1m2BTx4Uz" Ids="BCfKr0FAjAmNdA5kaC55Xd,OUKFJ9iuahYMx2zFZYRY5g" />
           <Link Id="CXfZGyIQUmDLfLzmQTligt" Ids="OfPiFZFtU1bQGlGqp3AQzo,BCfKr0FAjAmNdA5kaC55Xd" IsHidden="true" />
-          <Patch Id="PIIxrGbrZY8LUMnOh6gxfG" Name="Dispose" />
           <Link Id="GFzu0oZujGpPz0FkMG9AeM" Ids="SEUIGacq9XOMfaEz2wRBbA,E3N2zvSmw0lN57bPiD49EP" />
           <Link Id="R5QZnrACl9ePyXdjUXDaNe" Ids="OJlbgMSVvlgNdJeNIRtcpd,SEUIGacq9XOMfaEz2wRBbA" IsHidden="true" />
           <Link Id="S6xoJnrE9OGMXViZ2plFcs" Ids="Us7OQ22VvnbQJbD6g0suI0,OteLumLIkpbMYD7BtxsvPt" />
@@ -1467,6 +1506,58 @@
           <Link Id="RveScHlHYfwOqbYlOJHENj" Ids="McD0rxChkpRLOYuk7MplTj,NwQzLfrV2AGOAePvv75MPU" />
           <Link Id="G3X0lw997A6PG2xMaNu1jD" Ids="Ewzj4L0E9U6OYAXMS2ezDh,H2WWG9ZHfv3LMqW23agL6i" />
           <Link Id="IjRcGGZXYqgLP8Ol0URBTW" Ids="BW1aqDkFEILONSETbCIoaF,Ewzj4L0E9U6OYAXMS2ezDh" IsHidden="true" />
+          <Link Id="DLYnh3FFgPaQdmejVD8qws" Ids="D194eFIpaTxLntHnVFzUNp,RZ6nTtNAwQ8On0V7ZcenOJ" />
+          <Link Id="HdfEoO1VnTxPxyZelLUZN6" Ids="J8aZnWHx591NZ4zbZ6CLNv,TOeIUe7AQMoLhbCOBe7uqv" />
+          <Link Id="LSdGVBtnIi2OEjiTw0U3lh" Ids="SawQaa3S6qbLeCMoyza30H,F3qOUBvEhZFMYJWjfJjoVA" />
+          <Link Id="LG8rrZGYZRGMWZL28XIaMD" Ids="N2lQ5bKtEZOPMds4nF3kaI,FXJeTatbaq8M6Ksz95Nonm" />
+          <Link Id="IMjiTUKvBw7N49EDxQGP43" Ids="N2lQ5bKtEZOPMds4nF3kaI,B54ifXlmTEGQMLNC3GsIDi" />
+          <Link Id="BG4FAvMgzVAQVIFynQ0JnL" Ids="Qxvu5h0z7v3QT1yEtY2cZ6,SVnKISeDInoQKM2gmodVdE" />
+          <Link Id="AHpTaBgCQA6MuDqYqCbYpE" Ids="Tew9Bi8xHB9Qbne09BXUpm,Rs5hfOJ9V89P4Je9ji4s3N" />
+          <Link Id="CXZqqmbNNlTMrNe8WusDWC" Ids="ILQdnZ67z4IQBpfVRwdVp7,E3Dx6S3dz6gP4ruiqMMygT" />
+          <Link Id="Etdhn6A1vAzMtYn4vMC1D7" Ids="CWMzOV4bXL9NZRVTlPMDne,GJPVH3NtCKFPh6tqixHuqh" />
+          <Link Id="MhjPux5niCPLqoi0upsY6F" Ids="C2OR3i0ZA09P4KKBX6eTyC,JL7c2AGaqGiMSBPfJ72zvD" />
+          <Link Id="UGFsAPKpqyKOEhS4p4wWgR" Ids="D194eFIpaTxLntHnVFzUNp,JHqbUzxGsXNNAHDu4sk4HL" />
+          <Link Id="QzOquqDUI3COElhsUr3JVu" Ids="Mj73JmmQokTQaC7V1tfqnJ,V3Yg9CQUjy9NoEuG1UMW8f" />
+          <Link Id="F09RgCfA6htOVErHKcf4ct" Ids="RuDm93rPkNAOLblVLOwmQx,BZ6bOI7mpM8LUwN7AVMUsZ" />
+          <Patch Id="TuOkxV9syBxPwRTvVZB6JZ" Name="Create" />
+          <Patch Id="NPwec6eTeoYO8uqHWVKkZr" Name="Update" ManuallySortedPins="true">
+            <Pin Id="KFcV8Y1t85lMBfH2z1jXIF" Name="Listening IP" Kind="InputPin" Bounds="546,285" />
+            <Pin Id="OfPiFZFtU1bQGlGqp3AQzo" Name="Port" Kind="InputPin" Bounds="669,279" DefaultValue="4444">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="HWExlgqRXt1MKcqPYDVUCr" Name="Enable Data Preview" Kind="InputPin" Bounds="500,278" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="BW1aqDkFEILONSETbCIoaF" Name="Sort Data Preview" Kind="InputPin" Bounds="703,599" />
+            <Pin Id="MFV8Jj2EI1zMJQS5GVv3pQ" Name="Reset Data Preview" Kind="InputPin" Bounds="787,388" DefaultValue="False">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="OJlbgMSVvlgNdJeNIRtcpd" Name="Enabled" Kind="InputPin" Bounds="900,293" />
+            <Pin Id="LmJ7kikouupOoTBg8xiYF9" Name="Data" Kind="OutputPin" Bounds="741,310" />
+            <Pin Id="PsyNzSRWz6LM2vjdHCA4y5" Name="Data Preview" Kind="OutputPin">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <Choice Kind="TypeFlag" Name="Spread" />
+                <p:TypeArguments>
+                  <TypeReference>
+                    <Choice Kind="TypeFlag" Name="Spread" />
+                    <p:TypeArguments>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="String" />
+                      </TypeReference>
+                    </p:TypeArguments>
+                  </TypeReference>
+                </p:TypeArguments>
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="Gph0Y88wPqZMJjqgLqAnK6" Name="Is Open" Kind="OutputPin" Bounds="834,381" />
+          </Patch>
+          <Patch Id="PIIxrGbrZY8LUMnOh6gxfG" Name="Dispose" />
         </Patch>
       </Node>
       <Canvas Id="TshVZcgFWPzMtRWbg0h9kk" Name="Internal" Position="669,222">
@@ -2255,17 +2346,6 @@
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="I2P1B0C1x9HPLtnEWq8865" ManuallySortedPins="true">
-              <Pin Id="OjvimjMN7YZM6zFAWv2MeQ" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Sequence" />
-                  <p:TypeArguments>
-                    <TypeReference>
-                      <Choice Kind="TypeFlag" Name="Byte" />
-                    </TypeReference>
-                  </p:TypeArguments>
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="LH3JHJGRRIZQWHXFv6ehCE" Name="Output" Kind="OutputPin" />
               <ControlPoint Id="GIaQ42JL0UlPESULqb80af" Bounds="429,1224" />
               <ControlPoint Id="HoQoorm1997MnRjAcbJKUw" Bounds="429,1450" />
               <Link Id="P484BfOrobvLnQ1qKfnF6t" Ids="OjvimjMN7YZM6zFAWv2MeQ,GIaQ42JL0UlPESULqb80af" IsHidden="true" />
@@ -2321,6 +2401,17 @@
               </Node>
               <Link Id="JeeipFBbImWLH1iB1lcfx4" Ids="F5BB3ShY0uEMYY5iZm1XHO,JKzfJ4NYzbiNbIiKITYcey" />
               <Link Id="QzQw2AGsuMhPWCwWJVtOV8" Ids="CxmSdR31aMVLfOc2WxRta2,AlBFzDtubfSNh6l09MtWzH" />
+              <Pin Id="OjvimjMN7YZM6zFAWv2MeQ" Name="Input" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                  <Choice Kind="TypeFlag" Name="Sequence" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="Byte" />
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="LH3JHJGRRIZQWHXFv6ehCE" Name="Output" Kind="OutputPin" />
             </Patch>
           </Node>
         </Canvas>
@@ -2728,7 +2819,7 @@
               <Link Id="GnuQ7pYzF4YQSUCckiNTYs" Ids="SUF9ICMvp2FOXRlFCkaSMb,NdMNAvWmBnCL1PJ71xEUDY" IsHidden="true" />
               <Link Id="HhwEWcqb74FNglqsAWHGwU" Ids="P9UgMLpWjFINFb0legZBWB,SmRbQZjEwEfOTXcUyFWMtT" IsHidden="true" />
               <Node Bounds="1660,203,72,19" Id="PiCGVvgpHhWLX2fgQv37uh">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToFloat64" />
                   <CategoryReference Kind="Category" Name="Spread" />
@@ -2941,7 +3032,7 @@
                         <ControlPoint Id="E15QIQxzbSIMMQ8TLyr7Gy" Bounds="707,682" Alignment="Bottom" />
                         <Patch Id="Rd0u6OKCNXwLuRI0bbleYp" IsGeneric="true">
                           <Node Bounds="608,641,54,19" Id="Qi5W0gpgOvgMadd9fTfWU3">
-                            <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="OSC.Core.vl">
+                            <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                               <Choice Kind="OperationNode" Name="UnpackTimetag" />
                               <CategoryReference Kind="Category" Name="OSC" />
                             </p:NodeReference>
@@ -2966,7 +3057,7 @@
                         <ControlPoint Id="VAG9ZPad3gPMrLtaxLpKEt" Bounds="700,808" Alignment="Bottom" />
                         <Patch Id="Bug0ZWnQmBAPaKreS5DoLK" IsGeneric="true">
                           <Node Bounds="603,773,76,19" Id="BsaGcYUyVA9M71SWb7IVE2">
-                            <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="OSC.Core.vl">
+                            <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                               <Choice Kind="OperationNode" Name="UnpackInteger32" />
                               <CategoryReference Kind="Category" Name="OSC" />
                             </p:NodeReference>
@@ -3170,14 +3261,6 @@
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="L4R8mUDKs4rOu6iMUnK73b" ManuallySortedPins="true">
-              <Pin Id="NT4UDB75fqRL3q0qd4ttSF" Name="Input" Kind="InputPin" />
-              <Pin Id="APVoQeIhVA0OujSy7sdAtk" Name="Start Index" Kind="InputPin" />
-              <Pin Id="QuMzPgmvXToQeAKfCDhnmM" Name="Value" Kind="OutputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Char" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="U17kn4uk65UPWlsAd0iz8J" Name="Next Index" Kind="OutputPin" />
               <ControlPoint Id="V12cWCsTV38QcBhsSLLvbh" Bounds="1757,384" />
               <ControlPoint Id="IyofXv0jG4fOCvcrLd83SB" Bounds="1849,398" />
               <ControlPoint Id="DKg1UWX6MPdND1xhuMFzY2" Bounds="1756,576" />
@@ -3226,6 +3309,14 @@
                 </p:TypeAnnotation>
               </Pad>
               <Link Id="SMpiGTlqJIOOOaAkMTHeQd" Ids="B5Vyu20Rd3DPgsscGPN3cb,FxF14nJGunYO8tCaIlwnqm" />
+              <Pin Id="NT4UDB75fqRL3q0qd4ttSF" Name="Input" Kind="InputPin" />
+              <Pin Id="APVoQeIhVA0OujSy7sdAtk" Name="Start Index" Kind="InputPin" />
+              <Pin Id="QuMzPgmvXToQeAKfCDhnmM" Name="Value" Kind="OutputPin">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="Char" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="U17kn4uk65UPWlsAd0iz8J" Name="Next Index" Kind="OutputPin" />
             </Patch>
           </Node>
           <!--
@@ -3359,7 +3450,7 @@
                 <Pin Id="B0UgWa4H5HkM2feuA1fUBv" Name="Next Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="337,1657,62,26" Id="ObRXGj5mXgqPqYZcslyu43">
-                <p:NodeReference>
+                <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="Create" />
                   <CategoryReference Kind="Category" Name="OSCMessage" />
@@ -3530,7 +3621,7 @@
                 <Pin Id="DOTNmPx5ezSLgdIs9xDaUy" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="698,649,51,19" Id="OnsWKpUbf1yPMOLY7A92NA">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -3554,7 +3645,7 @@
                 <Pin Id="K18RiNxBYnIMNQmX7eETfz" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="574,694,36,19" Id="MK2sYnlfTW0O9roYJmzMRd">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="OperationNode" Name="Concat" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -3587,7 +3678,7 @@
                 <Pin Id="HcKEyN3WTWINxcS2eSFGlB" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="500,658,45,13" Id="QFHNa4S4vqDNvbbSCV2vLS">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -3725,7 +3816,7 @@
               <Link Id="BZWrIEs60W2MF0CMkQdoa9" Ids="Tj6lalNBjrtQbpp6FiPAm1,QajpK1tTYNjMCe3R9Npbu4" IsHidden="true" />
               <Link Id="PewCh6uzzZfPbUpXxUgxCA" Ids="H77SHkdmeYYL2hhgD7Flbj,Tj6lalNBjrtQbpp6FiPAm1" />
               <Pin Id="He2CGgOBTCiLGsZi5TXGSP" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -3779,7 +3870,7 @@
               <Link Id="EJSpfh673veOc5wFmu7cAm" Ids="D5tTW5PI2P8LYWQ2O1g1Tc,RRsyY0OpPMPO2nqPFKTtjk" />
               <Link Id="JpjI0VJugeKOkn97Mvmvv6" Ids="RRsyY0OpPMPO2nqPFKTtjk,O08vErRBewCLRXodFgGnIF" IsHidden="true" />
               <Pin Id="T4k9XW72L0JLmsnJhAlDzE" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -3837,13 +3928,13 @@
               <ControlPoint Id="LZmOVYZeJRkLbSgQoJW2ne" Bounds="157,424" />
               <Link Id="Hpe0VhwqepULJq65ASFHrx" Ids="LZmOVYZeJRkLbSgQoJW2ne,FcJTd4oEtSZQbVdloc1tnU" IsHidden="true" />
               <Pin Id="DNGdqyW6NTiOYyU9InZMUR" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PK1Bbb9yVP4Lmck8faGisN" Name="Args" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Sequence" />
                 </p:TypeAnnotation>
               </Pin>
@@ -3901,7 +3992,7 @@
               <Link Id="IwhU6EB8SkTOeyUVDfQiWo" Ids="QTBrg4ncVLyOSbBUgfnqki,HUepKb7e2hPP1RD1sKvhN1" />
               <Link Id="Ichlve5zEbwNQG5wRdXdr4" Ids="HUepKb7e2hPP1RD1sKvhN1,Qyx1WHZMFw9NRDaDqWwEqd" IsHidden="true" />
               <Pin Id="ItqTS49p7oqMydqTtK7EWm" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -3955,7 +4046,7 @@
               <Link Id="UfBSGxvHzzCLr5QGL7cBBo" Ids="Pq3GLKMrosbLx4wJD7Nbwv,IVvWeVWarVcN5znBmMvska" />
               <Link Id="TstI7fx9KZRPAQ5r96qc58" Ids="IVvWeVWarVcN5znBmMvska,EQlwGLg375pObatJ34fO5Q" IsHidden="true" />
               <Pin Id="MDBEdgGBIKdQP9eu4MvGF4" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4009,7 +4100,7 @@
               <Link Id="PTcUtV9UWt0OJ7z2zLFJgs" Ids="EziCChOY0IPQQczLK3mtJP,L9LUfQAEfE3MSkMka8qAbf" />
               <Link Id="VDSVfFPQsa0Nk5ZGnNpoAC" Ids="GxsmiHEXUYHNGoDzwLMdb2,H6Zb74oXprtLGUl1pA4p0X" />
               <Pin Id="S0qDjpvwOasN8CpbsNV5aO" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4081,7 +4172,7 @@
               <Link Id="PRjPhxzjIBqLnMgCwZVaIv" Ids="R6RkYD75hJOQNEq5A0JRZw,NoZ3Z00PJQ1LbVWQgMbn9Y" />
               <Link Id="Llb9g3BKkRyOLrxDJcJlxD" Ids="CZ93e0ffQ35QHyFKVV8UXC,EoZM0CZQSdvMR0A9wFxUNk" />
               <Pin Id="RH3jVnwLaBUO76Oemk57UN" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4135,7 +4226,7 @@
               <Link Id="TQ2xX7VZKsMNJayfM68YJp" Ids="EygQSP7cnuUMfvQwAdFywP,Sz9qOOdbgQwO1JSMrkknSm" />
               <Link Id="HOtHby0LgHyONz9YV9mACA" Ids="Sz9qOOdbgQwO1JSMrkknSm,KObASW20UrNMafd4277oeR" IsHidden="true" />
               <Pin Id="U0PEQZ0xAoDNSxENRE4vR3" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4189,7 +4280,7 @@
               <Link Id="F2hxSSY7AosQX4Odhg2tje" Ids="C3MXHBD6Ve3Nh8GvtDiYva,TV64DYpSBSoMYqc9k7Cpic" />
               <Link Id="DS8IlOXLRagMhx5VbueZ45" Ids="TV64DYpSBSoMYqc9k7Cpic,SSAhEdAgjDnPbxv3fcVNBo" IsHidden="true" />
               <Pin Id="QsTG5h26cqCQNzvVLkQpoT" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4243,7 +4334,7 @@
               <Link Id="TklVuQr8O2nORC6F6ahz8v" Ids="MoWnY1jIv87Mew7Awz4vy5,It8HH7ZR7WZPsVc4Ckv3BX" />
               <Link Id="Vqlico7B9TVPw3JpXOQXYo" Ids="It8HH7ZR7WZPsVc4Ckv3BX,UpPvFEhH5eLPPhSssjCfzv" IsHidden="true" />
               <Pin Id="FcGW1hGefNSLvHd18Gopqp" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4297,7 +4388,7 @@
               <Link Id="RfvQEX60UojQTQYvrdbgGp" Ids="V3VCcMVyYO8MKGVXZCj9jN,T3XW24r9GL8PXWlPOV9CST" />
               <Link Id="NJaoQgZVpHDLwXhflP4oRB" Ids="T3XW24r9GL8PXWlPOV9CST,NAhHI8wNA0SNlnOdoJ9sc8" IsHidden="true" />
               <Pin Id="R2Rv2y3Xs6ML7c93IwmYM1" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4351,7 +4442,7 @@
               <Link Id="HccWTQYuBzeQcaZ6wG5fHI" Ids="TDtpXWlh0PGO7JeDCpq66v,IpapLJsNVKUOPOJm8P6LyU" />
               <Link Id="NvRbOoAHI3LM8M3MAzby4P" Ids="IpapLJsNVKUOPOJm8P6LyU,KurVAzpgG3vNnP5xIRdb3f" IsHidden="true" />
               <Pin Id="VdIGSREf3kLM2aylrOq85u" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4413,13 +4504,13 @@
               </Pad>
               <Link Id="RF7EebUvhLyN3kb4ztBqKa" Ids="VgWlcsU1FbRNEHQAwIk3XY,MJg4XhNJymrOqQbSK1oA5o" />
               <Pin Id="F1xt8yHT0aMLfvkvIQAzHW" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="IkVbXcnZKsTMlL1ebKqmSs" Name="Args" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
               </Pin>
@@ -4460,23 +4551,6 @@
               <ControlPoint Id="BG2Hj1afQkHQYO1M4iaI6X" Bounds="156,2579" />
               <Link Id="QXJTgPJWupfOtt0wanLm8r" Ids="OGcao3myaUQQCZ5dOAoaKQ,BG2Hj1afQkHQYO1M4iaI6X" />
               <Link Id="LA98FVoHbk7LVNkd20tsW6" Ids="BG2Hj1afQkHQYO1M4iaI6X,C8ROlwSDki3MZBENq7TrxO" IsHidden="true" />
-              <Pin Id="OdKC7WRSR8CO4fajzf54bn" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="SerializationContext" />
-                  <FullNameCategoryReference ID="IO.OSC" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="CqNUHT43VTxNbfkOXtHFvS" Name="Args" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="MutableArray" />
-                  <p:TypeArguments>
-                    <TypeReference>
-                      <Choice Kind="TypeFlag" Name="Byte" />
-                    </TypeReference>
-                  </p:TypeArguments>
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="C8ROlwSDki3MZBENq7TrxO" Name="Context" Kind="OutputPin" Bounds="489,944" />
               <Node Bounds="297,2470,57,19" Id="AH0hEIOKlnxNtwW0Z8CbTd">
                 <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -4487,6 +4561,23 @@
               </Node>
               <Link Id="AyB6hSv57FCLSep6sX3olx" Ids="Q71UdNxwj76Nc34MvkM5Z2,UCcbZG85N2POB0nThFAVsi" />
               <Link Id="Epz8THcm1YxOcmqUNT6JKw" Ids="Vjl2GRCXFOMPbETYdfgrwd,VhhdwNAOwhcL3rTpVKr9Uu" />
+              <Pin Id="OdKC7WRSR8CO4fajzf54bn" Name="Context" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                  <Choice Kind="TypeFlag" Name="SerializationContext" />
+                  <FullNameCategoryReference ID="IO.OSC" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="CqNUHT43VTxNbfkOXtHFvS" Name="Args" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Collections.Mutable" LastSymbolSource="VL.Collections.vl">
+                  <Choice Kind="TypeFlag" Name="MutableArray" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="Byte" />
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="C8ROlwSDki3MZBENq7TrxO" Name="Context" Kind="OutputPin" Bounds="489,944" />
             </Patch>
           </Node>
           <!--
@@ -4534,7 +4625,7 @@
               <Link Id="KwvubA96jtbLHuqnSAUtcY" Ids="S943or7yUHFLuwXhJKxLN7,JWOpbajdomwMrZ2i1ZMfcT" />
               <Link Id="Q0P6gITIJuVQdtZqCmQrls" Ids="EwqxX7TuFv1M0bYakhvIWu,FdHJ2vioPxmNyZoB8JB1rV" />
               <Pin Id="SxYECMF3wpFOmgiNl0koeC" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4588,7 +4679,7 @@
               <Link Id="FckV3EBSkrRQTSYlxqN2HX" Ids="T8HD99Awt5nQNWbpzlwjk9,Ktlf4xF9HaRK9jhBq98NPS" />
               <Link Id="AOwvEOsP6qqLPmES5hT1W2" Ids="DIImYcYJjc1QTnuGuDmRUY,DhH1523M8V0LXiomWYcC89" />
               <Pin Id="NSMitYTP47hNL6DvODvsGP" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4672,7 +4763,7 @@
               <Link Id="Tclvxix4nP7ORlnY0r3b6k" Ids="NIySaWOlEgGLUMREyeMMkc,IIEApMPHbinNLGsrhAwRmS" />
               <Link Id="EqEoYBEf4qZQQhPzZlkgWQ" Ids="T5wuDZWArnqQJuxw6z6zRy,J3lyBW4qJi5LaIgFogGhmZ" />
               <Pin Id="UuRofCUEwgtLAM7CdbqLBI" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4768,7 +4859,7 @@
               <Link Id="Q89s1nbXUGpQX7pAo8oHT6" Ids="KgTcVBBfr7cPYPwGS9Dma6,GUsxh9abGyoMs4d3bUmHgR" />
               <Link Id="LWM4G4UPc8NLkQDN9i1q50" Ids="B6ohnvYUFxUPyVojWuc1c1,Bgn2fkYETihMvIU8zFfIr3" />
               <Pin Id="BwcEUXlKePGOLE58fZabTI" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4876,7 +4967,7 @@
               <Link Id="NtT6kPm29SuOWb0Ct8racn" Ids="QniUSG09WxAQd1OZcOCUZD,QCSzvVn7tNwOfVrAV7vO4j" />
               <Link Id="GqZMOcAByW4MUBpT3ExF0b" Ids="JlLGIZyCMZfNEeVVPNGHfA,JjFoi1ibpa3OBa5ElUsZoM" />
               <Pin Id="QKDQ6wt1Oq2LLbRoGU9F30" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4996,7 +5087,7 @@
               <Link Id="DFB7GXIOxy4LVnxt6yznNJ" Ids="OOQCFf8XLXmMF4svMFcwKZ,BvE8YcUW7aBO11ykwZAQBA" />
               <Link Id="GAyDADhPwYBMawFpn5vywR" Ids="TKVvyzIMMFbPDgsqUP3ZTY,SpKB8JTYNJXLDqP1t1yuoS" />
               <Pin Id="BmF7h3gIEKwPqrwWY9bPs4" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5128,7 +5219,7 @@
               <Link Id="JGLe60s8FR1M9qEQgZwWkL" Ids="Ueai7Ij0ZGfMQ9TPFkMb5D,USQyKA9UOzEM4h3Q4FEM03" />
               <Link Id="NvPChedMRIdLY9d9SiYuDm" Ids="NpNg3t2Cfu3OztfUMPW3g9,VTwoLZeJCABOFhgMMDsUu1" />
               <Pin Id="GbtyeivguBfNpYXPg0NniH" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5188,7 +5279,7 @@
               <Link Id="LOsQ4gAK29BOV9uGPRy6NO" Ids="ROs1a5hURC8NMWN1rp8Y2J,VgqJPZ1WropQafVsBo8x8N" />
               <Link Id="SYB5LtOXdtqMkFOcA7YtSu" Ids="VgqJPZ1WropQafVsBo8x8N,EzUcpTZmsR6QWTjUHH4Lek" IsHidden="true" />
               <Pin Id="I3TMCYlteitMOTnD3T85oO" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5260,7 +5351,7 @@
               <Link Id="AsDjptfes3jPxjwiYK1hG3" Ids="EKoRKN5hHVoOOxp0joBTLO,I14tsg55nzDPZcwmEFCTZy" />
               <Link Id="UcRuZXHiNBSMpdhqurWEGi" Ids="TxibxEgzp5vLJv9DdkPgmN,GGkgAy73RRrQNNtgFlnmaP" />
               <Pin Id="UPgwyzK6XEGK9mAzMi8mMM" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5344,7 +5435,7 @@
               <Link Id="MaL4xYZ9CuvMjd7GwpxFxH" Ids="VwiK247qD7ULceReadixWd,DejHYRRpI92LJMC4Pgtzub" />
               <Link Id="G0sUFmGHDnpPBS3nKwPcav" Ids="INXRSA7fDnVNknvlDmysOH,I9lbPyeIfNDPZ5XJiz73xA" />
               <Pin Id="B17gg3sjZhaPfRLQuLXgjS" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5440,7 +5531,7 @@
               <Link Id="KovKWaMQC8xO1PGjBTcDVH" Ids="MtIO8Zb1SZMOvtqBoUec7b,NiXPBFSHLEbPORu0HBQzAv" />
               <Link Id="Qhdism8r8G3PBzyp9mCobY" Ids="QMXlzRZzzq1QJXaKVLpbpi,AHhoOnBHtVNQdWSJD9wdwu" />
               <Pin Id="NTAbVryI3yRNOx9EF2r6bh" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5548,7 +5639,7 @@
               <Link Id="R7iGOmjb6V4O8IrXtTmGHp" Ids="DyQFMZYkoo9OcTUETVaTYo,USzTMyxBQoRLps9oNqUNVu" />
               <Link Id="PW5Yh1pssHWMO71O9DrKVL" Ids="DappMBYbFI6NZrxXuMwsnG,Q8yZP4TL5unNG9siaC9BUW" />
               <Pin Id="GuMjTHEgpIZPfbDlHjopsC" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5668,7 +5759,7 @@
               <Link Id="H0OHyDX3PsNMTsWe0DjVsU" Ids="RaJyNX5itbtORFm9lhsZVN,DBJlCB5V4TDNwoMhaoRFh8" />
               <Link Id="CSil6GcxrZdLEVkbPoHo5h" Ids="DqDAXZR5DV2LnXM3H7rhOP,KSMFMpixvrpPqyDzkXJrH1" />
               <Pin Id="QyqDbjvPxAuOGR4HoM7ia4" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5800,7 +5891,7 @@
               <Link Id="DTEiWRf7yEXPaAICdD44LG" Ids="MWfKbQX4ZzXOu06NKbgUdT,U9vgRmhk6pIL9Dg2yrupjM" />
               <Link Id="HLSiSsGNNlpLtTfIcl0DZc" Ids="L2c90ufIUjOMIopOj68pXh,LTVERgVgsIcNbT3RCL7FSJ" />
               <Pin Id="Pdoz4o7b7dAM6sV15EIVyA" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5836,12 +5927,12 @@
               <ControlPoint Id="Iu50lQkValTMapKmPmXKMW" Bounds="246,195" />
               <Link Id="MRCH1vE6zhvL8e5oWUZqcS" Ids="Iu50lQkValTMapKmPmXKMW,S3TTMHRZB3HN7zChThsRLf" IsHidden="true" />
               <Pin Id="GxXTMbQoFmjN2yvpxGVoAp" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="P6IbpXAYYkNNogb4EYY33H" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -5851,23 +5942,23 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CSmqRS0LVdLM3oZUL0mmh3" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="L3l6ZpmxSQuLeDIXOrSUQV" Name="Byte Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QUwandi7I8xPrErTKqYuHV" Name="Args" Kind="OutputPin" />
               <Pin Id="S3TTMHRZB3HN7zChThsRLf" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="FyVfPJPKqs8OHLy1kcQYWa" Name="Next Byte Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -5923,7 +6014,7 @@
               <Link Id="T4c326PUrGQL7Moeg20dRL" Ids="KLCMJF8ZxDrMzDg5L9Bhc7,Sl0xznLVavVP1mQn1NqjYi" IsHidden="true" />
               <Link Id="KbWKCljHUEvPF0vVCaMpPr" Ids="MmCHGpbp5t3Lpg75FaJ0Fh,KLCMJF8ZxDrMzDg5L9Bhc7" />
               <Pin Id="Unr4dm9oxWlMj9YPPOAt6R" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -5933,20 +6024,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Jrns9196nMoPuYLkZ8XUZm" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="Vwyuwa9uMUnNHUJlQcgJVB" Name="Args" Kind="OutputPin" />
-              <Pin Id="P95tMp21rSuM8C3C9ZoM4Z" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TUi8uTEx9GBMmM2OQCs8qL" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="F3DekJArRzoPXDWGQZqfoM" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="Vwyuwa9uMUnNHUJlQcgJVB" Name="Args" Kind="OutputPin" />
+              <Pin Id="P95tMp21rSuM8C3C9ZoM4Z" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="Sl0xznLVavVP1mQn1NqjYi" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6002,7 +6093,7 @@
               <Link Id="NhK5iOqP0piOYBoT6XgdtC" Ids="Q7ULKMe5QOKLe2tgFEkXGJ,PryrP4YGNWtP0zO6Q36boV" />
               <Link Id="UHgQ8EHzRoCLxhnJ9TbbB4" Ids="VNkOQ3pLSjoLxrSwttXkDT,EYVZyVKu8X8LAasxD5FzEG" />
               <Pin Id="IfAovDqH7W5LEaP6pQAtci" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6012,20 +6103,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D1UdsVYDR86ORidL5P5Ohp" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="TuFT6RVy3wxNAwFSHPbIrv" Name="Args" Kind="OutputPin" />
-              <Pin Id="I2NqnS23pGBP5uXJrSYuH4" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="Qt5WMZBPeFfMv1LRxSIkfA" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="EcFpTtm5AlTL1LxkjJ2NKu" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="TuFT6RVy3wxNAwFSHPbIrv" Name="Args" Kind="OutputPin" />
+              <Pin Id="I2NqnS23pGBP5uXJrSYuH4" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="AXeTmDqHn4VL2SqkhQEt7v" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6100,6 +6191,8 @@
                       <CategoryReference Kind="Category" Name="Primitive" />
                     </p:NodeReference>
                     <Pin Id="L0plobY7KmlLytj75nTlkH" Name="Condition" Kind="InputPin" />
+                    <ControlPoint Id="OTVn5ANKEcsQStXYw7VwPX" Bounds="354,550" Alignment="Top" />
+                    <ControlPoint Id="BvcxOWSNAqeNoH4VgaGQCW" Bounds="351,641" Alignment="Bottom" />
                     <Patch Id="LyWLSNpKCGwQEN9onCfS9Z" ManuallySortedPins="true">
                       <Patch Id="F9l8aBomkIXNJaUB0w2FTV" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="VIssxGh6hlKQcbU817nBE0" Name="Then" ManuallySortedPins="true" />
@@ -6133,8 +6226,6 @@
                         <Pin Id="Sl8xCd6RbmsNxkq60Tz2OG" Name="Chars" Kind="OutputPin" />
                       </Node>
                     </Patch>
-                    <ControlPoint Id="OTVn5ANKEcsQStXYw7VwPX" Bounds="354,550" Alignment="Top" />
-                    <ControlPoint Id="BvcxOWSNAqeNoH4VgaGQCW" Bounds="351,641" Alignment="Bottom" />
                   </Node>
                   <Node Bounds="334,512,37,19" Id="CC6BiG1fmlpMHIgQCoAY7s">
                     <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
@@ -6188,30 +6279,6 @@
               <Link Id="JCeqEdx3VmGQdtWEqDmuWt" Ids="NeY9ijFtvAAMbW9VO5KI8y,EZ54c6NK2uTPXYdSyXm96c" />
               <ControlPoint Id="EZ54c6NK2uTPXYdSyXm96c" Bounds="297,727" />
               <Link Id="AVKGFE3hkOuNw3E0RaZukJ" Ids="EZ54c6NK2uTPXYdSyXm96c,EZYebRcrxnOMk0YUgtKBVf" IsHidden="true" />
-              <Pin Id="RdlqYDMH1ugN1PbRtrvR63" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Spread" />
-                  <p:TypeArguments>
-                    <TypeReference>
-                      <Choice Kind="TypeFlag" Name="Byte" />
-                    </TypeReference>
-                  </p:TypeArguments>
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="QSGKwD8gnaBLDCPcPbUvN1" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="String" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="FZVPAx0AoY1NVididCZAPN" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="DXnriZWD2BDOjUh24AotRW" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Integer32" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="BpGei0wQmh2Qb1jRuyLgp1" Name="Args" Kind="OutputPin" />
-              <Pin Id="EZYebRcrxnOMk0YUgtKBVf" Name="Next TypeTag Index" Kind="OutputPin" Bounds="303,601" />
-              <Pin Id="Cn9LOu8RzpTPfi8Wyil0Y5" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Link Id="Ijhrrgiwi1COwHUa86xiXW" Ids="MXpRS8klXWCLnhnYNI03CW,Cp35dTV04quNqXTCtJKA6s" />
               <Link Id="HqzRdQ4ftR0OJqYaqAkgNx" Ids="Bungh0d5KzBLF7Ypxfedih,IBl5xGUd2trQVwhC40H7B3" />
               <Link Id="U3yM2McjKF8OUNKs6iu6bj" Ids="AMsoyryW9oNNPAYcXCbtep,Sap6vQOSt3rNXT9JSgUj0m" />
@@ -6233,6 +6300,30 @@
                   <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                 </p:ValueBoxSettings>
               </Pad>
+              <Pin Id="RdlqYDMH1ugN1PbRtrvR63" Name="Data" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                  <Choice Kind="TypeFlag" Name="Spread" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="Byte" />
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="QSGKwD8gnaBLDCPcPbUvN1" Name="TypeTags" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="FZVPAx0AoY1NVididCZAPN" Name="Byte Index" Kind="InputPin" />
+              <Pin Id="DXnriZWD2BDOjUh24AotRW" Name="TypeTag Index" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="Integer32" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="BpGei0wQmh2Qb1jRuyLgp1" Name="Args" Kind="OutputPin" />
+              <Pin Id="EZYebRcrxnOMk0YUgtKBVf" Name="Next TypeTag Index" Kind="OutputPin" Bounds="303,601" />
+              <Pin Id="Cn9LOu8RzpTPfi8Wyil0Y5" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
             </Patch>
           </Node>
           <!--
@@ -6309,7 +6400,7 @@
               <Link Id="PVCYsHNnH7lQIpIwRvz9pC" Ids="RMStW2eSIS1PviheJdYJps,KJzlkNOZEmHPfu1A00zlgj" />
               <Link Id="UoidCm1nG5HLO9ZdOf7x1H" Ids="Beaj3zqr8yMQUJ4cAL6Ip4,VVx4b4P5aUjLqCgpCkyLMG" />
               <Pin Id="IMwipLZj7c0OTivJ6y62qB" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6319,19 +6410,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Re48s7aIDd7QYRHdS65CjC" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D4CgLUKf1z5MYllmDfJJ2Q" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Kvcu67pnM8XLzobAwjJfnx" Name="Byte Index" Kind="InputPin" />
               <Pin Id="TCfjGeAwj1fO3N1Cm2nb1h" Name="Args" Kind="OutputPin" />
               <Pin Id="Q2B4Yj1vh2zPA2Wwi4epfg" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6419,7 +6510,7 @@
               </Pad>
               <Link Id="IW5Ow5w8ZHzQSlOxkoPEs5" Ids="H5yinC5d66pLoPkvlUlvnP,Mnj7JsDIDQmQUAG0bHAaf3" />
               <Pin Id="JWJygOqHguAPXGnG3So0KB" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6430,19 +6521,19 @@
               </Pin>
               <Pin Id="DmdFcuzrVNvOrveaE52yUA" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Fi8ZvyqZdMZOpO6syaqc66" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LZSZUfjrYKLLJrMwqCNzlk" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="NSVfyGIujm0NEDBXPxQuWd" Name="Args" Kind="OutputPin" />
               <Pin Id="Pw3I1INmIJaLbeQh5DCX5L" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TOcGiY4tT7gO3vmnYRU7sK" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6498,7 +6589,7 @@
               </Node>
               <Link Id="RPSZJpGWLPuMSCG2sWRTAC" Ids="T1ZV6BTsex8M084AhPCbkO,NG0wJVgxT1TMplqOCck0wV" />
               <Pin Id="Aq8BixapqSSMNMxnE2kieJ" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6508,20 +6599,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PzuEOOFS9wyLJMIrRe2YLF" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="M5t57jGw20ZN0a7L7eQSD7" Name="Args" Kind="OutputPin" />
-              <Pin Id="FxM5S4grP7aOIGyb8zyqSB" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="AmkT3x9hLAyPpf2z1RUp9N" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="RK1QaKH5PhhNsESqTPOFwi" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="M5t57jGw20ZN0a7L7eQSD7" Name="Args" Kind="OutputPin" />
+              <Pin Id="FxM5S4grP7aOIGyb8zyqSB" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="IdPyRPypzZuO6gvlEERJ9B" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6577,7 +6668,7 @@
               <Link Id="IUYuNkY0lMrO3bGKMH2nDQ" Ids="VltU3aY2MPoODO15IcUP36,TPWQ0VrkxXIOcXddKRFi6w" IsHidden="true" />
               <Link Id="Sm1mZMEJFvfMWj8yoZLhE2" Ids="BiKH4rzqXUNLXKOGus40Yl,VltU3aY2MPoODO15IcUP36" />
               <Pin Id="OKlovQj0qaGPzyT245ARkn" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6587,20 +6678,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="SHnUByAteqGOb78lG32Cet" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="HelZeBiU2tpOzLBPyKU14X" Name="Args" Kind="OutputPin" />
-              <Pin Id="Kgd9qavgysrLU0f0I28sIL" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="B4LcGwISMsBPIt8IICO8Bi" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LRLkX4ZE7hwOfxLjvbwGam" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="HelZeBiU2tpOzLBPyKU14X" Name="Args" Kind="OutputPin" />
+              <Pin Id="Kgd9qavgysrLU0f0I28sIL" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TPWQ0VrkxXIOcXddKRFi6w" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6699,7 +6790,7 @@
               <Link Id="S0rvCf3e6oUMWKp6uIEJ1l" Ids="BfB9lWjjeTaOrrtTbs2B1r,NuAP89wtmduQbDxPWc2QP5" IsHidden="true" />
               <Link Id="NsF5n8jxuEqMWavmyctVor" Ids="NuAP89wtmduQbDxPWc2QP5,DbIyS5Rp8qCMDCEF7b89m8" />
               <Pin Id="En1QwZKhrEpMIrLTeksw0e" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6709,19 +6800,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Kfjz9J6E5ymOt1tdKJhlzB" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BfB9lWjjeTaOrrtTbs2B1r" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="UcJiKwE5b9bNi1UGruzrOO" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Smdrc0ZL0JZLIkqE7OuNUX" Name="Args" Kind="OutputPin" />
               <Pin Id="DGzVKJJSogELI8ivq7Qf1W" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6778,7 +6869,7 @@
               <Link Id="JscLSbiJ49sMVSsr7xEIhY" Ids="CRhymXRK16CMvR1J65rJyO,QY7U8s8VotjPEPJ8LLCaVn" />
               <Link Id="GZrLc5r0M4VQGa5jJNfS1q" Ids="AITvNmcb2KhPsYg9PuDxNW,I0YYAQ4XmUMMuGDCJEUVno" />
               <Pin Id="NiqulPlXGJHLsINLGWCe4x" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6788,20 +6879,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BES8pK9mWJfNfr9rUBcDGd" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="QQ2mBQMASMZMvKoW6zIFWk" Name="Args" Kind="OutputPin" />
-              <Pin Id="HC6J52COzDYQOarOd4qk28" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="CZWNr76nJgZL37XqVsZgbk" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Pr60KS1jshaLDDhk1lCL2t" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="QQ2mBQMASMZMvKoW6zIFWk" Name="Args" Kind="OutputPin" />
+              <Pin Id="HC6J52COzDYQOarOd4qk28" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="NfE04egi8dpOo0Wgk2J4MR" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6857,7 +6948,7 @@
               <Link Id="Hi2wSFaHXjoMC1w5KOYjTU" Ids="RBtdopV5yvzLgrSqO2RNx1,LDn5wHJpJBBLolPfx2eVrs" />
               <Link Id="R5KqHnkqLNtPfxBIs8KFeD" Ids="TjG8WupHLpQOKpNxK58qeE,Nb3c1IiiTXUNZ1nTmvubpi" />
               <Pin Id="F9DKPjWumvAOHuaq51vnqX" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6867,20 +6958,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="T32euGldqezPWoZb3WiJbh" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="GllO6sJAd68N4lCg91ezLk" Name="Args" Kind="OutputPin" />
-              <Pin Id="KMET04s46HnPLhFtQBtNFu" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="SqpH0ejcJEgPQMAJuLttEQ" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="B1KZH35lsHYOwQtxn76kKi" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="GllO6sJAd68N4lCg91ezLk" Name="Args" Kind="OutputPin" />
+              <Pin Id="KMET04s46HnPLhFtQBtNFu" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TBcmgZ2QXNMP04Tl43nROv" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6936,7 +7027,7 @@
               <Link Id="GLIvqf3F4MSN06z3FCl1st" Ids="LAza4o7DjRFNRh25DZ6dVH,BG5O0YYRFRhL1twGv2AYaA" />
               <Link Id="V79R9VysUpnO7hbXSW4AQD" Ids="Ua8tv2084GZP2lxsFQrTLD,VplAgdQJZHVPVeiCPIKrj9" />
               <Pin Id="UGU8Ta6UQjJMLpWd3DxN1o" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6946,20 +7037,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="JiFgGj6oeR2N0mwgd9I2XZ" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="LRBmu7LpamhPa8d8PM4WkM" Name="Args" Kind="OutputPin" />
-              <Pin Id="QYcia6hlOozLiD4wmn4MvQ" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="LHzXugVk6qGNaqm94Sq4a0" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="DMdjKKWmtChMuiNlQt8dAq" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="LRBmu7LpamhPa8d8PM4WkM" Name="Args" Kind="OutputPin" />
+              <Pin Id="QYcia6hlOozLiD4wmn4MvQ" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="Hm7UM1E5bxpOzWdpUlu037" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7015,7 +7106,7 @@
               <Link Id="IrtJcrwMeQyOa76GXXt1lG" Ids="GxojIbSaXOWOMJVRHkBQO4,AUx1kVkCpCXQb7Y2E95ILD" />
               <Link Id="QtN4ZgaGtUNLKyURgbYJlA" Ids="UMyrUSX1akbNWR30IGpWqj,HTlfFo2t6CpLCXsXSIKmlx" />
               <Pin Id="MiDPEbYgAbiPA84ioVapCQ" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7025,20 +7116,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BVPxLyO50vAPv5aEb7GLDP" Name="Byte Index" Kind="InputPin" />
-              <Pin Id="LGB3VxghEbZLalNW42jpfU" Name="Args" Kind="OutputPin" />
-              <Pin Id="DTEuUoa10jDOzvfz3C0Lxv" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="Q87WG8IX6rvNCjyEyYjhiK" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CO582Edutd0PaytWvHUmjo" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
+              <Pin Id="LGB3VxghEbZLalNW42jpfU" Name="Args" Kind="OutputPin" />
+              <Pin Id="DTEuUoa10jDOzvfz3C0Lxv" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TCe4HPPKA02LNAIi9riNCT" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7139,7 +7230,7 @@
               <Link Id="ARcVm7fqar8OQw1678jtHh" Ids="QtjTCElAPBFNgkXaGKfQi7,SHgsDtmZGONP8bzYXexXMf" IsHidden="true" />
               <Link Id="PRe6WtKN5uuNlyBGD9mzJ9" Ids="M1svye3JuAiNIZIkfpItNF,STBzGEZPrUzPoHyhkagzVN" />
               <Pin Id="PRYlXpHG3IjQYcRzXk5AJK" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7150,19 +7241,19 @@
               </Pin>
               <Pin Id="O1VoHBXVj7GLsrBJUhU7HY" Name="Byte Index" Kind="InputPin" />
               <Pin Id="QtjTCElAPBFNgkXaGKfQi7" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Bzha7qGzsFcPMjlmYAQfII" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Md48noJAKkaPaqF0XLhvwK" Name="Args" Kind="OutputPin" />
               <Pin Id="QYEzCBVIQ6GN7rDLa9eIIR" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="HaJHjLpp5JULgHjLHaEXcG" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7277,7 +7368,7 @@
               <Link Id="OjmJoCmPkncLPOFI5incFp" Ids="BGDMs7jurFHLAk8vTef6Np,JbXwmCrL6kSMsaTkmLiB4b" IsHidden="true" />
               <Link Id="KH4IaOb9MjXO2X9xbFPMhB" Ids="Dft8M2kO6JcLuJ6PFZ8lQi,AS6JCvJ3OlcOuPBsVy4wOD" />
               <Pin Id="OwrkCTULJIsO2W3cMicbmj" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7288,19 +7379,19 @@
               </Pin>
               <Pin Id="P8ca1KaHzx2P65yCPZdYPu" Name="Byte Index" Kind="InputPin" />
               <Pin Id="BGDMs7jurFHLAk8vTef6Np" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LsJ70OuipIeMcqu549n42r" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="JVY5ncDCqwiNdNASUpliKZ" Name="Args" Kind="OutputPin" />
               <Pin Id="Hmz3dkpjPmbLmnzKCwGEZx" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TFlRxECxzfiL9YMJUdflrZ" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7372,7 +7463,7 @@
               <Link Id="PPpyuQlopxuOy4DTXwUDfi" Ids="NUmN2u4bXESPKJ3eoQ0B1u,KfH7DW9ztsxMmjtCiQu4nw" />
               <Link Id="LaZcKt0W398M3rGJsfU4ZD" Ids="TIhvj61slsYLMJKPCfBgBb,Lg87Sa4IxGTNJEt9DmVBcw" />
               <Pin Id="CB2HIdjqmcoMvIOwDRHimd" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7382,23 +7473,23 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D6O7NYI93QuL1t4Rga1oYV" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="FrOED3gz16YO8c93FZSJhh" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PfnmiNJRcUWO5ft9H3Itua" Name="Byte Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="G5wIs5B7FAaP7Wd9m4iMFy" Name="Args" Kind="OutputPin" />
               <Pin Id="IyENwMgQlyaNhtWys8xjsE" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7517,7 +7608,7 @@
               <Link Id="QgGtEWQDxszO1rbKgl6l8k" Ids="S41x5liVKnQNxAUldDSqf9,MXVnWR9FGsFOvNcz81KUfG" />
               <Link Id="Pky1AG9UcULMWGi8nXK0hD" Ids="LH08qmBIoQ9MbSDMtvKZTQ,FNgGXOC70NQNqdDmpeYUiT" />
               <Pin Id="ELfqNRuFZUvL9SeQyYz90L" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7527,19 +7618,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="TlZNfIgFTo1PUyHaL1AFJ1" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BClgTyCOAlnL2pZZgrloNy" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AN1CFVQUB22O0vjiyIUNQD" Name="Byte Index" Kind="InputPin" />
               <Pin Id="OZeuXAeo8QQObAey5Tpohe" Name="Args" Kind="OutputPin" />
               <Pin Id="IepNpDxlLYCNjOXwQtadgq" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7677,7 +7768,7 @@
               <Link Id="Fb8cNljM95ZO4NKv7ST1d5" Ids="Laal3b6T8F0MLqvJR0IJS7,ELQvxdL0TLfOiGMQBAAY7y" />
               <Link Id="MjnGgpJHez2LzGafFzHy3o" Ids="PLorpxjekDaLNBNyXeAwC0,QpkloZQBrNjLT95ORmNtVc" />
               <Pin Id="CuPdl4PAh2GQcwGf7Lt39p" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7687,19 +7778,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D8DKPPPBYAbOnzxjsvAEZT" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="ObjRKypXQisODNS0bpvmh3" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="I9bppO47UFSLbEj5qwqBvZ" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Suv31t2GfGCOX2Bqlq94ka" Name="Args" Kind="OutputPin" />
               <Pin Id="FsK0tecIhTsNyECMhFXTHb" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7856,7 +7947,7 @@
               <Link Id="ReRnFmikCujPiqy6RGPmBK" Ids="DznHOJtshewQWxL541rM89,JncUhZyNVAXOtfzbSomzNB" />
               <Link Id="BBtaGbS9o3ALVY10YuDYgB" Ids="Spt3BmsOTjvMhnAHMWkvR1,KSpvJOXGIkqP6UoqPAk1OI" />
               <Pin Id="NHANpUjTAF9LMoWNCh0PDx" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7866,19 +7957,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QOYyPMiQy8VNuiVTNx57nj" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AABhZwTjUdUPyL9X36cZ4k" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="IL4Xnrf6RhALM6FBnnvo1f" Name="Byte Index" Kind="InputPin" />
               <Pin Id="F4b7iJuBQJmLIY8Xepywmz" Name="Args" Kind="OutputPin" />
               <Pin Id="R7yQZ9gjXaZOXqNe4w0H5N" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8054,7 +8145,7 @@
               <Link Id="HpfhY7uShR0PL5fNPcrrmc" Ids="SwAr7Jx090sOOjFF0oGBsC,TLuxc3RoPGjP4hovS8nAKH" />
               <Link Id="V6ySTnQeyfQOPoql9Hpqva" Ids="KzWXfyltWEIMhypC6pwOuG,KEIjvD8YOJALvQQWz1t6xC" />
               <Pin Id="VF4U1SuY0FoL8aouWemnXV" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8064,19 +8155,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="P9w0DGOLHCrPEmE3TOzUq6" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="EmMFWVnToezLbyeF1Jdb6O" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="UUnpZc7KSmkOVqw5d0wgIU" Name="Byte Index" Kind="InputPin" />
               <Pin Id="No0YxEfpTGePIfPPCaZf1h" Name="Args" Kind="OutputPin" />
               <Pin Id="UGg21ajcYS0Nx81RTkW0CN" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8271,7 +8362,7 @@
               <Link Id="AMERr0nzzxLPClxQlQnMBb" Ids="E15BMtGmXUCPCeqTrvuCUq,OyaLZSdQvkGO3OvYabYjud" />
               <Link Id="NQVh74rndElMkFFsblEey8" Ids="PyhZKOdYXKxMCA5THUJZAU,LbyelF0tWB9ORq765jaAHI" />
               <Pin Id="Iam4sUI2YrpP54kxfNPzqg" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8281,19 +8372,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AgfcdrwO85fOvxLIt24yVH" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="JXMP1H3TrciNC2OQPpv6OT" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QXEvXG5Yu62LQZcSCiS0BP" Name="Byte Index" Kind="InputPin" />
               <Pin Id="QVMCu3IkxStQc0458sZqGI" Name="Args" Kind="OutputPin" />
               <Pin Id="LKO1YJF8ssbMg2NcYPVBQa" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8374,7 +8465,7 @@
               <Link Id="JdjLncmfN5XPsBRiSrAARM" Ids="ArotmEKGp8wNp7IUxC7tZx,FyH0hRarQO0MUTlWhAJXCN" />
               <Link Id="VBldFL45FM4MtKuGolqJKV" Ids="De7w50BZSQdM19qbeMJSJk,QFPExXpSj3FOXy50l3Ugxz" />
               <Pin Id="O5fE2SvrCehNaZwXXhj3vB" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8384,19 +8475,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="S95wptH0TbCOXEchbM508g" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QE34V9gMGtONkYGJHl58TO" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="C8KtaNgBt6sPu64VBfKSxW" Name="Byte Index" Kind="InputPin" />
               <Pin Id="JMvWz16JI0VMZxoQxJPN58" Name="Args" Kind="OutputPin" />
               <Pin Id="Sx2GVjdpEYHM5UxAQlVPGt" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8496,7 +8587,7 @@
               <Link Id="OTDOxic3jLELSeyPVkZXVX" Ids="TVLgqHm5PT3Nhy1eAmU0uL,QCrIzWGMLhjQWD6Wv1Fcqt" IsHidden="true" />
               <Link Id="E0ka3hSXEJDNfcVnm5cbln" Ids="QCrIzWGMLhjQWD6Wv1Fcqt,PeMZdwhin9tPK3HgjQq8nS" />
               <Pin Id="B9p79BJHyrfLuXEJJyGm0F" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8506,19 +8597,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="OONMLZyVyJyP4S9TIrGl1X" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="TVLgqHm5PT3Nhy1eAmU0uL" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="NoXenGizTKOOI5ujlT7cGY" Name="Byte Index" Kind="InputPin" />
               <Pin Id="S6Y61YHAFKWMk08iFtc2uK" Name="Args" Kind="OutputPin" />
               <Pin Id="AbmUMIwN55EPMkZaabwARx" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8637,7 +8728,7 @@
               <Link Id="TG9kEKowj1mLiS6gti0C0G" Ids="QpGONtpjg4bL3YcF4V1Al6,HR8MDKXMjyXQDEB3rcC2aJ" />
               <Link Id="EOiMEV5eQIdMHQTrqlVciP" Ids="J3pLJxoNedKODEcayX05EO,RUFPyo8gOqfOdWQFk7pBR3" />
               <Pin Id="CHRg7PDDK6aMOcMsDkxpew" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8647,19 +8738,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Spa8uJK39U7NIwKyP4Lkbj" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QO2wDyXIhZMPNALK6F8yB1" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="DTeVpH9EWFoP5C6V80DLRs" Name="Byte Index" Kind="InputPin" />
               <Pin Id="GAizjxSUeyNNJwd5AH4Uds" Name="Args" Kind="OutputPin" />
               <Pin Id="BW5FZXkqmcYQKXA2qoTnAI" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8797,7 +8888,7 @@
               <Link Id="KGIs241mTzDLbJCmCBzAcu" Ids="RlXtA0P6EU5MiuV7eftlln,Bj7tbRzccSSNw1b7t8ZK5z" />
               <Link Id="AXPzoxSunr4Lo9rZVArMk1" Ids="G6F74ggsMk9L2dwd3JqpP9,MYfG7dPBHt2OiQDbrcyK35" />
               <Pin Id="DRkwQ5pzcACOzC1e34Kspv" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8807,19 +8898,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BCQ8ZeOIPQGNLQV0GxnJXl" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="R95909XLIhtL2OztTGE4nx" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Plkn3YFsMxMMjCCkMCRT69" Name="Byte Index" Kind="InputPin" />
               <Pin Id="MmOm8I2iIHpNcz3T7BX8Z8" Name="Args" Kind="OutputPin" />
               <Pin Id="SrCEgWsZWPVOXpa6Ivuyvl" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8976,7 +9067,7 @@
               <Link Id="HTfW8oN1rrDNbWVgabHXSv" Ids="R40L5GnuDyaO66kBJvxMVS,KEb0sv3WTZJOOPOAGS7RPs" />
               <Link Id="Hrc6FHm0kfZNy1QKKCx335" Ids="QgX6jgfcLmaP3rcIndsaHB,FXryXFQ5riLLkCd8WVPPW0" />
               <Pin Id="C0NRqaBfYZDPdEKx6nB9gi" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8986,19 +9077,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AIqwG57C8NsPrYvrglLwEN" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QrrMP7kITGlOYZfbP7oRPM" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CNRPpVdZOk1N6iqur3Dnbk" Name="Byte Index" Kind="InputPin" />
               <Pin Id="EiWhbEj1BQdPQoGIuSAg8J" Name="Args" Kind="OutputPin" />
               <Pin Id="RTrgJYilqzONxZgbNV6DzK" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -9174,7 +9265,7 @@
               <Link Id="Gb5tXvR7wMONv7PLD5YFOs" Ids="QI4uCHJskQHMAUjIePp4ju,BXN0JqnILtMLmTioUwHSHG" />
               <Link Id="CKudJ6HBqsLL5zASTqRFsH" Ids="Clkq2W5TOzCMj8e14cfvEs,J7EwhhTVfpvNRKNrEYGltZ" />
               <Pin Id="Jh5ttOR2kWEPZHn9rWXt93" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -9184,19 +9275,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PNVtM2smjzNOpZnraVPEsA" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="J8zq2GfoF0zMgYJfb7OLFH" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="MhIrBTIxriIPfcRFr6ndr5" Name="Byte Index" Kind="InputPin" />
               <Pin Id="M4wHqY9vmaJLdyNocCGnwS" Name="Args" Kind="OutputPin" />
               <Pin Id="EJUcry8TVVzMqLBYJ4T0dE" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -9391,7 +9482,7 @@
               <Link Id="KJPzs2MqIc3LftnO1wWelq" Ids="VCv0wHlwcDmNRj7umElJwf,OtuG6s3A1xeLbVPCMyevbo" />
               <Link Id="IKNtMcmOAR0Oo5wFaIpbof" Ids="CsZzl0yA9IJMEIFOZBb64S,BIuAsYnnbXONjPuX60iuhe" />
               <Pin Id="KsHVYR1EptyQcvDWNjSCbT" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -9401,19 +9492,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="RohxiKqW4HAOVCapcFkt9f" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LxeMtUNndrUOV7MV8HpR4o" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="GXzHSwG80cyPNShumHGaei" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Rz286jEpXYINsuIKoIbIuv" Name="Args" Kind="OutputPin" />
               <Pin Id="URLSnpHMncxPfEEwF4FxlL" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -9500,6 +9591,8 @@
                 <Choice Kind="OperationCallFlag" Name="Where" />
                 <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
               </p:NodeReference>
+              <Pin Id="QX5JKzFuCPXPxDPirmBToq" Name="Input" Kind="StateInputPin" />
+              <Pin Id="EDoqgcdIGhfLha9PkWdB48" Name="Output" Kind="StateOutputPin" />
               <Patch Id="RcfOR6uYZ44MmLxj9vSSSg" Name="Predicate" ManuallySortedPins="true">
                 <ControlPoint Id="QAotI0xI3XQPutjjT3eXcf" Bounds="1133,492" />
                 <ControlPoint Id="ATUomT2IxNlPqQL8LBXoQ3" Bounds="1153,590" />
@@ -9513,7 +9606,7 @@
                   <Pin Id="RMMsC3Elq9iNqMaMLtuljH" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1131,510,65,26" Id="Rc8bzlXbFtQNuewNCAy4WT">
-                  <p:NodeReference>
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9528,8 +9621,6 @@
                 <Pin Id="IoqWAwRFnkFOSTB2jNvt9c" Name="Input 2" Kind="InputPin" />
                 <Pin Id="MV02WgHS5hAMKt8DPZ36m1" Name="Result" Kind="OutputPin" />
               </Patch>
-              <Pin Id="QX5JKzFuCPXPxDPirmBToq" Name="Input" Kind="StateInputPin" />
-              <Pin Id="EDoqgcdIGhfLha9PkWdB48" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="1119,655,120,134" Id="Cq6tsdILZQAL70R9kqU0cR">
               <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
@@ -9560,7 +9651,7 @@
                   <Pin Id="KzFyYSEtgRRLaN7wiDwLhD" Name="Next Byte Index" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1132,688,65,26" Id="IAqXvcjGwHWOd75BW4NP6B">
-                  <p:NodeReference>
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9636,19 +9727,8 @@
           </p:NodeReference>
           <Patch Id="BsMMsSl6saGN9g8xO8kQ4j" IsGeneric="true">
             <ControlPoint Id="DJxkb4idFJNPRTUsf5y9RB" Bounds="797,468" />
-            <Pin Id="GNcLTGWxR4fPv1VhTE7ep7" Name="Input" Kind="InputPin" Bounds="439,915">
-              <p:TypeAnnotation>
-                <Choice Kind="TypeFlag" Name="Sequence" />
-                <p:TypeArguments>
-                  <TypeReference>
-                    <Choice Kind="TypeFlag" Name="OSCMessage" />
-                  </TypeReference>
-                </p:TypeArguments>
-              </p:TypeAnnotation>
-            </Pin>
             <Link Id="EqcJnW5XhBoOLTCCPxfKXP" Ids="GNcLTGWxR4fPv1VhTE7ep7,DJxkb4idFJNPRTUsf5y9RB" IsHidden="true" />
             <ControlPoint Id="SyRnUiiqmnnNfZV6n7841P" Bounds="964,506" />
-            <Pin Id="R7BfY7KJst6QYpXb1jORmp" Name="Address" Kind="InputPin" Bounds="529,914" />
             <Link Id="EcnDSQT9W4VLNeZF8gEgzu" Ids="R7BfY7KJst6QYpXb1jORmp,SyRnUiiqmnnNfZV6n7841P" IsHidden="true" />
             <Node Bounds="794,514,124,113" Id="P6qQVVTI2cZPD3D1OacUEd">
               <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
@@ -9674,7 +9754,7 @@
                   <Pin Id="ENzecjE6kTIMKcU0ztCZlt" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="806,540,65,26" Id="LHo1binQw0AOFs25gyJ1nQ">
-                  <p:NodeReference>
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9729,7 +9809,7 @@
                   <Pin Id="O1yCUQSeka4Lkt9D9RtQPG" Name="Next Byte Index" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="832,738,65,26" Id="IhfyJydhPNYNTLpbRNjPk1">
-                  <p:NodeReference>
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9743,7 +9823,6 @@
               </Patch>
             </Node>
             <ControlPoint Id="EnM2QCbGMHlONU0RYeitQs" Bounds="815,866" />
-            <Pin Id="AtepfbNQXbzLRQvYesr3nJ" Name="Output" Kind="OutputPin" Bounds="1475,1263" />
             <Link Id="MitrhrES3FsPqx3DAwqhEx" Ids="VBuNK7HzheOMIgzFGLdENo,RPv3fQMhT5uOBFAsX2gvkw" IsHidden="true" />
             <Link Id="T4G3hwPzlbML60zilm1WIV" Ids="FitA9BWP7FWPDLpkILFhpJ,RKqqriamUEJP8tIVvukIJH" IsHidden="true" />
             <Link Id="LaxrRE6Lj2kMJLyMqfkJml" Ids="SUIaaqcFO2cNfsKlutwrbh,DPdVwzrIfyZPIHC85gXHbr" />
@@ -9763,8 +9842,20 @@
             <Link Id="F2whP89E3UkQBplIzvQRlq" Ids="SyRnUiiqmnnNfZV6n7841P,TnEhspKQLjaNOlylhJ5Fud" />
             <ControlPoint Id="PEQjOYqdf12LTAcTFFrVwV" Bounds="952,729" />
             <Link Id="EUoPMZTirx9QUO7XOSAPnv" Ids="SlFgFDoOjoVOjRPzDujF7W,PEQjOYqdf12LTAcTFFrVwV" />
-            <Pin Id="VxL3wBYyFP6NMevSYD8c72" Name="Is Matched" Kind="OutputPin" Bounds="952,729" />
             <Link Id="ENVswrrujcVNH3JCD2vSVq" Ids="PEQjOYqdf12LTAcTFFrVwV,VxL3wBYyFP6NMevSYD8c72" IsHidden="true" />
+            <Pin Id="GNcLTGWxR4fPv1VhTE7ep7" Name="Input" Kind="InputPin" Bounds="439,915">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <Choice Kind="TypeFlag" Name="Sequence" />
+                <p:TypeArguments>
+                  <TypeReference>
+                    <Choice Kind="TypeFlag" Name="OSCMessage" />
+                  </TypeReference>
+                </p:TypeArguments>
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="R7BfY7KJst6QYpXb1jORmp" Name="Address" Kind="InputPin" Bounds="529,914" />
+            <Pin Id="AtepfbNQXbzLRQvYesr3nJ" Name="Output" Kind="OutputPin" Bounds="1475,1263" />
+            <Pin Id="VxL3wBYyFP6NMevSYD8c72" Name="Is Matched" Kind="OutputPin" Bounds="952,729" />
           </Patch>
         </Node>
         <!--
@@ -9876,7 +9967,6 @@
                 </p:TypeAnnotation>
               </Pad>
             </Canvas>
-            <Patch Id="LCEIyNRSXKcMS27s3HsJ6y" Name="Create" ParticipatingElements="Qyqz0vycblJO4D5ICe5RUu" />
             <ProcessDefinition Id="HlEHUfrcrNJMQTV8cDLCC7" IsHidden="true">
               <Fragment Id="I83Zg9cL7xuNIH3ntxtdCh" Patch="LCEIyNRSXKcMS27s3HsJ6y" Enabled="true" />
               <Fragment Id="TTHuoD5ulQVQcfCohS5STz" Patch="Vm676ZMDGXONdZSIlFHGXS" />
@@ -9884,23 +9974,6 @@
               <Fragment Id="V0Zga6H5nwrPyjv1o0J4BG" Patch="AbFXtZqY6P3Ph7fFnuYRLj" />
               <Fragment Id="OtIre7CdNZnNFWa2PdLVmu" Patch="OsDif6FLXvLN2kdyWww35F" />
             </ProcessDefinition>
-            <Patch Id="Vm676ZMDGXONdZSIlFHGXS" Name="AddArguments" ParticipatingElements="PtuM6qnxlKnNBjXAuZHeDQ,G3Wu9gX6S6OOhASzEf9IBT">
-              <Pin Id="Uh13tgRfBJ6NESc3RBmGv1" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="String" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="AXGBruHvA03LaEDf4Va4NS" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Sequence" />
-                  <p:TypeArguments>
-                    <TypeReference>
-                      <Choice Kind="TypeFlag" Name="Byte" />
-                    </TypeReference>
-                  </p:TypeArguments>
-                </p:TypeAnnotation>
-              </Pin>
-            </Patch>
             <Link Id="PPL8lWxsritMdbCC5Kaini" Ids="HwvNlJDbUUkOSZ1iqi9k28,SiDiekPhgYULsO7eoFld2Z" IsHidden="true" />
             <Link Id="QuOrywiFw32LkfB3JnBhfM" Ids="Uh13tgRfBJ6NESc3RBmGv1,J8eE8c5CbHtLtdXrfjFTP3" IsHidden="true" />
             <Link Id="PQx11Rs8GC4PqDnFJMClSb" Ids="AXGBruHvA03LaEDf4Va4NS,Vq3XS4P6ijsPjxjt2htJZK" IsHidden="true" />
@@ -9908,12 +9981,6 @@
             <Link Id="DwS9ezlYg0GNgdQJYjJzvy" Ids="Vq3XS4P6ijsPjxjt2htJZK,UUycTEXVWQPP9pZkcpgHAA" />
             <Link Id="TadPRQ5O6zkQEYr7S1tkcE" Ids="GpgrQUL6U17PbM82SSbKxb,Lcg9UiP7IHdO1OxMr9j9XL" />
             <Link Id="KzDdR41GD7KM5c0z5BUSqr" Ids="PZRtdIGBe8wPm0vE0cfAbC,OETtOIFomPCQBO2wwjPFh2" />
-            <Patch Id="NmG55SHqkx6NEu7RaizlmO" Name="SetAddress" ParticipatingElements="J55VETc8cDjM2Pn3yqTeHl">
-              <Pin Id="HwvNlJDbUUkOSZ1iqi9k28" Name="Address" Kind="InputPin" />
-            </Patch>
-            <Patch Id="AbFXtZqY6P3Ph7fFnuYRLj" Name="GetBytes">
-              <Pin Id="AJr2LwIAqmlMyxrSQrx6Dd" Name="Result" Kind="OutputPin" />
-            </Patch>
             <Link Id="M6hUPlorhe2NXgp1JONNrV" Ids="Jwud5JtZ3PcPEoTlHAawRA,AJr2LwIAqmlMyxrSQrx6Dd" IsHidden="true" />
             <Link Id="KooN7ZgKahOM4Thj2Yw1pU" Ids="HYs4VMqjSHLPe9m5uJ2V7N,ObruhQjY4bqLTd5gQ3ZK4A" />
             <Slot Id="Ml4Bc0K7e1xMMG1x7ZgGzj" Name="TypeTags" />
@@ -9927,10 +9994,34 @@
             <Link Id="JW57irM9p6gMOO303AkC74" Ids="P6JHqOxNXdAOa6Fg75jiyo,EgcurmdOXGZM7u8pqcunWG" />
             <Link Id="SNor3BXiYzNLR26tbjR6ji" Ids="Lcg9UiP7IHdO1OxMr9j9XL,SM9Bdr2b9mwP4dj2lIFvvC" />
             <Link Id="AAUffe5VFX9O3OMx48K8aV" Ids="ObruhQjY4bqLTd5gQ3ZK4A,DA1ZgM2fqVfQNKE15ZYRqv" />
-            <Patch Id="OsDif6FLXvLN2kdyWww35F" Name="Clear" ParticipatingElements="NtgaG1lyJfFNrPky0utu2Z,PpA770r9WzOPRjtWxo6a4W" />
             <Link Id="PpA770r9WzOPRjtWxo6a4W" Ids="UVCShewDlBPLnLuXFt6juX,PZRtdIGBe8wPm0vE0cfAbC" />
             <Link Id="KPjfIIu8hBIOdnfgrPvd69" Ids="JVNH8PYwXJbMIUoGNmB5sE,Jwud5JtZ3PcPEoTlHAawRA" />
             <Link Id="CupAnIRZUMPNpkP64nFaA3" Ids="ObruhQjY4bqLTd5gQ3ZK4A,BJJanerJ0dEOOVUJ8tjHB2" />
+            <Patch Id="LCEIyNRSXKcMS27s3HsJ6y" Name="Create" ParticipatingElements="Qyqz0vycblJO4D5ICe5RUu" />
+            <Patch Id="Vm676ZMDGXONdZSIlFHGXS" Name="AddArguments" ParticipatingElements="PtuM6qnxlKnNBjXAuZHeDQ,G3Wu9gX6S6OOhASzEf9IBT">
+              <Pin Id="Uh13tgRfBJ6NESc3RBmGv1" Name="TypeTags" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="AXGBruHvA03LaEDf4Va4NS" Name="Data" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                  <Choice Kind="TypeFlag" Name="Sequence" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="Byte" />
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
+            <Patch Id="NmG55SHqkx6NEu7RaizlmO" Name="SetAddress" ParticipatingElements="J55VETc8cDjM2Pn3yqTeHl">
+              <Pin Id="HwvNlJDbUUkOSZ1iqi9k28" Name="Address" Kind="InputPin" />
+            </Patch>
+            <Patch Id="AbFXtZqY6P3Ph7fFnuYRLj" Name="GetBytes">
+              <Pin Id="AJr2LwIAqmlMyxrSQrx6Dd" Name="Result" Kind="OutputPin" />
+            </Patch>
+            <Patch Id="OsDif6FLXvLN2kdyWww35F" Name="Clear" ParticipatingElements="NtgaG1lyJfFNrPky0utu2Z,PpA770r9WzOPRjtWxo6a4W" />
           </Patch>
         </Node>
         <!--
@@ -10093,6 +10184,8 @@
                 <Pin Id="AWHna9JvxIcMHm7HMhd1rj" Name="Dispose Cached Outputs" Kind="InputPin" />
                 <Pin Id="PeU0aR8jYL6Mn2BHsA0xfc" Name="Has Changed" Kind="OutputPin" />
                 <ControlPoint Id="IzqH36VTo5kQdD23hgT5wA" Bounds="329,1021" Alignment="Bottom" />
+                <ControlPoint Id="DrXvdSFVj37N7dHt3X6GFB" Bounds="637,310" Alignment="Top" />
+                <ControlPoint Id="PfSu8zg1JqDPTZfUr0PiGw" Bounds="743,1021" Alignment="Bottom" />
                 <Patch Id="C32SOkfZjvqLqdAjA33wh4" ManuallySortedPins="true">
                   <Patch Id="B28uDJUEK7XPlQsSlgwbGK" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="Tcq4OhEv6ycLAy7fPBK2Fe" Name="Then" ManuallySortedPins="true" />
@@ -10142,7 +10235,7 @@
                             <Pin Id="LnIYiMf5jS4N4YhigbNGTY" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Node Bounds="575,804,53,26" Id="IjJUpEMqerwPlhsPsTOZ02">
-                            <p:NodeReference>
+                            <p:NodeReference LastCategoryFullName="VL.ISolution" LastSymbolSource="VL.Lang.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="MutableInterfaceType" Name="ISolution" />
                               <Choice Kind="OperationCallFlag" Name="Confirm" />
@@ -10156,7 +10249,7 @@
                             <Pin Id="IXYP4sDfs7bPAM77hnSiad" Name="Output" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="575,725,99,19" Id="R7aoxWFueSXNpChCOzti66">
-                            <p:NodeReference>
+                            <p:NodeReference LastCategoryFullName="VL.Session" LastSymbolSource="VL.Lang.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="Category" Name="VL" />
                               <Choice Kind="OperationCallFlag" Name="CurrentSolution" />
@@ -10203,7 +10296,7 @@
                             <Pin Id="T9KPSGmkIPLP7RWdhX3qaS" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="517,598,65,26" Id="U6PWGq8a2iINYHoODyJuD8">
-                            <p:NodeReference>
+                            <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="RecordType" Name="OSCMessage" />
                               <Choice Kind="OperationCallFlag" Name="Split" />
@@ -10252,8 +10345,6 @@
                     <Pin Id="PumdUHLC7tzPPhYR72XeDj" Name="Output" Kind="StateOutputPin" />
                   </Node>
                 </Patch>
-                <ControlPoint Id="DrXvdSFVj37N7dHt3X6GFB" Bounds="637,310" Alignment="Top" />
-                <ControlPoint Id="PfSu8zg1JqDPTZfUr0PiGw" Bounds="743,1021" Alignment="Bottom" />
               </Node>
               <Node Bounds="589,84,51,26" Id="QKP9OSfBIObQZVWbWMPi1N">
                 <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
@@ -10294,8 +10385,8 @@
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pin>
-                <Pin Id="PDt8ouUvfoZMO9iiBHiWTH" Name="Output" Kind="StateOutputPin" />
                 <Pin Id="E2Bzhwxa6R8OvwIuOnvGSo" Name="Apply" Kind="InputPin" />
+                <Pin Id="PDt8ouUvfoZMO9iiBHiWTH" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="743,223,51,26" Id="NH8TGmgTVJgPl32sb68eyE">
                 <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
@@ -10351,6 +10442,7 @@
                       <CategoryReference Kind="Category" Name="Primitive" />
                     </p:NodeReference>
                     <Pin Id="KxkkKiHa28GLHoD9XlbEQn" Name="Break" Kind="OutputPin" />
+                    <ControlPoint Id="Knkxu7zOYvsPpYyenjBeVN" Bounds="423,1281" Alignment="Top" />
                     <Patch Id="RCwhih21JjPMZs8sl8LDQi" ManuallySortedPins="true">
                       <Patch Id="I7BswEn36uFOhZXBlcXgGz" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="D4QFCRQSKLhNsOmexMP8hQ" Name="Update" ManuallySortedPins="true" />
@@ -10366,7 +10458,6 @@
                         <Pin Id="BczRUMBpIBlO1Yb6c1teo6" Name="Output" Kind="StateOutputPin" />
                       </Node>
                     </Patch>
-                    <ControlPoint Id="Knkxu7zOYvsPpYyenjBeVN" Bounds="423,1281" Alignment="Top" />
                   </Node>
                   <Pad Id="E7G4NX8aNweMFLE2Us0SoT" Comment="" Bounds="345,1402,35,35" ShowValueBox="true" isIOBox="true">
                     <p:TypeAnnotation>
@@ -10390,35 +10481,6 @@
               </Node>
               <Pad Id="EpPwC2eyjn6Lob3DhZv7nh" Bounds="547,1192" />
             </Canvas>
-            <Patch Id="J1K5w9E8yqZOkeRUpNrPsj" Name="Create" ParticipatingElements="QKP9OSfBIObQZVWbWMPi1N,ESnJHgwpII5LJWKmQ3lebf,NO2waxbCPlSN2wHyRRZE3d">
-              <Pin Id="K4zCV5iBTkLMrdPqA2QlcN" Name="Node Context" Kind="InputPin" Visibility="Hidden" />
-            </Patch>
-            <Patch Id="HKu1lX8wQYbQXeyi8qXQAL" Name="Update" ManuallySortedPins="true">
-              <Pin Id="NMVt67EQ0dVOJBe3CZEFTr" Name="Input" Kind="InputPin" Bounds="445,239">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Observable" />
-                  <p:TypeArguments>
-                    <TypeReference>
-                      <Choice Kind="TypeFlag" Name="Spread" />
-                      <p:TypeArguments>
-                        <TypeReference>
-                          <Choice Kind="TypeFlag" Name="OSCMessage" />
-                        </TypeReference>
-                      </p:TypeArguments>
-                    </TypeReference>
-                  </p:TypeArguments>
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="R1wzxpnNQ3JMyCbQivCjyc" Name="Address" Kind="InputPin" />
-              <Pin Id="Ri7xCHfsIGFOocRXJt5uMc" Name="Learn" Kind="InputPin" Bounds="604,345" />
-              <Pin Id="ErJMA9TnfvWNYP8pVZVdF9" Name="Output" Kind="OutputPin" Bounds="398,558">
-                <p:TypeAnnotation>
-                  <Choice Kind="TypeFlag" Name="Observable" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="F2MG7NsfLFBMvOwxiOX1ls" Name="Is Learning" Kind="OutputPin" Bounds="302,345" />
-              <Pin Id="D02fhlCT7LLQAYP9JiFDYO" Name="Address" Kind="OutputPin" Bounds="636,228" />
-            </Patch>
             <ProcessDefinition Id="CZKE5cmlqn0NQAB4fNWsLC">
               <Fragment Id="Ge0DPlxNhB8K93p7Hm5Z1s" Patch="J1K5w9E8yqZOkeRUpNrPsj" Enabled="true" />
               <Fragment Id="OON9pxAmnRlPUHlx76VdqM" Patch="HKu1lX8wQYbQXeyi8qXQAL" Enabled="true" />
@@ -10483,6 +10545,35 @@
             <Link Id="KBn67yytq3dMxHck7RolkB" Ids="Knkxu7zOYvsPpYyenjBeVN,LOtW4pzxxEAPeE9VHncXdn" />
             <Link Id="CAXOorXkGJQLMCH3HDtUNc" Ids="EpPwC2eyjn6Lob3DhZv7nh,CR0bvcVHmcVNQG6zlACFUO" />
             <Link Id="Lw4dOTKRfZLLjUFnS2U75f" Ids="E7G4NX8aNweMFLE2Us0SoT,KkSwtQhbhV1OcGkQdUVvaa" />
+            <Patch Id="J1K5w9E8yqZOkeRUpNrPsj" Name="Create" ParticipatingElements="QKP9OSfBIObQZVWbWMPi1N,ESnJHgwpII5LJWKmQ3lebf,NO2waxbCPlSN2wHyRRZE3d">
+              <Pin Id="K4zCV5iBTkLMrdPqA2QlcN" Name="Node Context" Kind="InputPin" Visibility="Hidden" />
+            </Patch>
+            <Patch Id="HKu1lX8wQYbQXeyi8qXQAL" Name="Update" ManuallySortedPins="true">
+              <Pin Id="NMVt67EQ0dVOJBe3CZEFTr" Name="Input" Kind="InputPin" Bounds="445,239">
+                <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                  <Choice Kind="TypeFlag" Name="Observable" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="Spread" />
+                      <p:TypeArguments>
+                        <TypeReference>
+                          <Choice Kind="TypeFlag" Name="OSCMessage" />
+                        </TypeReference>
+                      </p:TypeArguments>
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="R1wzxpnNQ3JMyCbQivCjyc" Name="Address" Kind="InputPin" />
+              <Pin Id="Ri7xCHfsIGFOocRXJt5uMc" Name="Learn" Kind="InputPin" Bounds="604,345" />
+              <Pin Id="ErJMA9TnfvWNYP8pVZVdF9" Name="Output" Kind="OutputPin" Bounds="398,558">
+                <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                  <Choice Kind="TypeFlag" Name="Observable" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="F2MG7NsfLFBMvOwxiOX1ls" Name="Is Learning" Kind="OutputPin" Bounds="302,345" />
+              <Pin Id="D02fhlCT7LLQAYP9JiFDYO" Name="Address" Kind="OutputPin" Bounds="636,228" />
+            </Patch>
           </Patch>
         </Node>
         <!--
@@ -10507,13 +10598,6 @@
             <Link Id="PxRwoN8J1bRLPLJKHgs1kC" Ids="KCWvW6gDzYGQRd4o7Ejfhs,DNDScUxiMKuOFTIvqf59XA" IsHidden="true" />
             <ControlPoint Id="F7Rm7nk7lzRLa8Wo3k2A9D" Bounds="462,1182" />
             <Link Id="IzWBHLRTQjyLi9vyf4NYVU" Ids="QcvLVUhDP9ULYIfhok9kT4,F7Rm7nk7lzRLa8Wo3k2A9D" IsHidden="true" />
-            <Pin Id="KCWvW6gDzYGQRd4o7Ejfhs" Name="TypeTags" Kind="InputPin" Bounds="1160,709" />
-            <Pin Id="QcvLVUhDP9ULYIfhok9kT4" Name="Data" Kind="InputPin" Bounds="1172,728" />
-            <Pin Id="HhGRpbntTruQFMS2VcyhxM" Name="Output" Kind="OutputPin" Bounds="1091,906">
-              <p:TypeAnnotation>
-                <Choice Kind="TypeFlag" Name="Object" />
-              </p:TypeAnnotation>
-            </Pin>
             <Node Bounds="408,1227,83,19" Id="AdKnR2Uus88Nh0UElrMjsn">
               <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -10892,6 +10976,13 @@
             <Link Id="GynUN9XMYVnPYFI6dMGmNB" Ids="GxJJ9eWajEuMIycVFw5Snm,AFBTVzuaEoQN9UnfTpAb5c" />
             <Link Id="A3y86dGqLuGMeio7nswkZG" Ids="M19Gajaz5VoLaarK0VUwMM,Bjh0EV9p2OpOxhONkLQgc5" />
             <Link Id="LYUEpsrRfYRMSm1vXhNGeu" Ids="PMmGNTKE95pLiEagixdrxl,BCwvLZ5r3AZQLJsxU38Kng" />
+            <Pin Id="KCWvW6gDzYGQRd4o7Ejfhs" Name="TypeTags" Kind="InputPin" Bounds="1160,709" />
+            <Pin Id="QcvLVUhDP9ULYIfhok9kT4" Name="Data" Kind="InputPin" Bounds="1172,728" />
+            <Pin Id="HhGRpbntTruQFMS2VcyhxM" Name="Output" Kind="OutputPin" Bounds="1091,906">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Object" />
+              </p:TypeAnnotation>
+            </Pin>
           </Patch>
         </Node>
         <!--
@@ -10972,28 +11063,28 @@
             <ControlPoint Id="RFd9XzHDJgmNUFIatU4E51" Bounds="812,1362" />
             <Link Id="U8zH0JnelHiOasqC7USLCU" Ids="TUOAcbY9fXDLu1TmtDruut,RFd9XzHDJgmNUFIatU4E51" />
             <Link Id="H2TFHs55DG5Ln5eH8HytcM" Ids="RFd9XzHDJgmNUFIatU4E51,VIYmgfZsX0EMhJVW32dgVJ" IsHidden="true" />
+            <Link Id="So632av9ZloOVKywPqi66T" Ids="Ivne2YTYAeaM7pxSKp68A1,FgGzGFU6skLM4hIAnItKqu" IsFeedback="true" />
+            <Link Id="KlplGpFH33kPO8Mf3S7Xk7" Ids="FgGzGFU6skLM4hIAnItKqu,DmrfIQFaSECOUfxtEKVKF5" />
+            <ControlPoint Id="DmrfIQFaSECOUfxtEKVKF5" Bounds="788,1448" />
+            <Link Id="LExLpIUVUjkOPbPjNRObsQ" Ids="DmrfIQFaSECOUfxtEKVKF5,GhBGwptJqhzMiPU6kz0LGF" IsHidden="true" />
+            <Link Id="EcSioWwVcJOLqjvt333ZeC" Ids="BpPEWSGxl0FNANVodKL4YN,FgGzGFU6skLM4hIAnItKqu" />
+            <Link Id="C1JV7G0rR8POspSjUZA41y" Ids="BpPEWSGxl0FNANVodKL4YN,ABDoa5VYOIqL9xXWSS3Baa" />
             <Pin Id="Q26nSI3Jne9PpPTNOU7k5t" Name="TypeTags" Kind="InputPin" Bounds="794,1317" />
             <Pin Id="I0vfilf5Y7RMaRZcGswCaz" Name="Object Passthrough" Kind="InputPin" Bounds="844,1360" />
             <Pin Id="AqtjIDEL7usOdIyH46Js7q" Name="Data" Kind="InputPin" Bounds="869,1380" />
             <Pin Id="MEgQA5dRNYeLQ60QkwBGEc" Name="TypeTag" Kind="InputPin" Bounds="873,1328">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="NoRmnc4htULOgSopUfY0dB" Name="TypeTags" Kind="OutputPin" Bounds="793,1534" />
             <Pin Id="FzIVuCpdCLxOJrFie7dMn9" Name="Object" Kind="OutputPin" Bounds="845,1520" />
             <Pin Id="VIYmgfZsX0EMhJVW32dgVJ" Name="Data" Kind="OutputPin" Bounds="940,1447" />
-            <Link Id="So632av9ZloOVKywPqi66T" Ids="Ivne2YTYAeaM7pxSKp68A1,FgGzGFU6skLM4hIAnItKqu" IsFeedback="true" />
-            <Link Id="KlplGpFH33kPO8Mf3S7Xk7" Ids="FgGzGFU6skLM4hIAnItKqu,DmrfIQFaSECOUfxtEKVKF5" />
-            <ControlPoint Id="DmrfIQFaSECOUfxtEKVKF5" Bounds="788,1448" />
             <Pin Id="GhBGwptJqhzMiPU6kz0LGF" Name="Type" Kind="OutputPin" Bounds="915,1525">
               <p:TypeAnnotation>
                 <Choice Kind="TypeFlag" Name="T" />
               </p:TypeAnnotation>
             </Pin>
-            <Link Id="LExLpIUVUjkOPbPjNRObsQ" Ids="DmrfIQFaSECOUfxtEKVKF5,GhBGwptJqhzMiPU6kz0LGF" IsHidden="true" />
-            <Link Id="EcSioWwVcJOLqjvt333ZeC" Ids="BpPEWSGxl0FNANVodKL4YN,FgGzGFU6skLM4hIAnItKqu" />
-            <Link Id="C1JV7G0rR8POspSjUZA41y" Ids="BpPEWSGxl0FNANVodKL4YN,ABDoa5VYOIqL9xXWSS3Baa" />
           </Patch>
         </Node>
       </Canvas>
@@ -11067,7 +11158,7 @@
           <Patch Id="C2ZvpASCmo1PCqbEV32R3M" Name="Create" />
           <Patch Id="TG9AsIrgEWuNHlQNzUkbsv" Name="Update">
             <Pin Id="ThwAMMHQFHMO9QyFUYi3Kf" Name="Input" Kind="InputPin" Bounds="448,271">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -11138,10 +11229,11 @@
           <Link Id="ErFMhAnypfDP18XVPfto5e" Ids="NJZdmPfmUdYOtwGlJAE2Gx,QPAWcDR1GdaQE9acaZeUFn" />
           <Link Id="D8Jgmg4v5LyLDwuXdoqaIs" Ids="OD6fsSHGOz7NxGeobp2t0q,SUne6u1B23XNRbOCElaBnO" />
           <Link Id="GTxl5Ojs4r1MD2RD9zLlw1" Ids="SUne6u1B23XNRbOCElaBnO,EOndWlrPmVCLFHm7JDdKKS" IsHidden="true" />
+          <Link Id="PtD2FgRc290L8zsx7BRRBm" Ids="UwWrvVlB5KKOLNQf0ThUKS,HjVGwPyh96INC5UkuImZnh" />
           <Patch Id="RhcbHcHlgPbNKIL8kY13qO" Name="Create" />
           <Patch Id="ApEtAdff4z7QalhHYhrPe3" Name="Update">
             <Pin Id="QJxC4B7W4COLItCFzplfTb" Name="Input" Kind="InputPin" Bounds="377,288">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -11152,7 +11244,6 @@
             <Pin Id="KlUYT12h1xcQBYtQwIc55J" Name="On Data" Kind="OutputPin" Bounds="795,513" />
             <Pin Id="EOndWlrPmVCLFHm7JDdKKS" Name="Address" Kind="OutputPin" Bounds="486,426" Visibility="Optional" />
           </Patch>
-          <Link Id="PtD2FgRc290L8zsx7BRRBm" Ids="UwWrvVlB5KKOLNQf0ThUKS,HjVGwPyh96INC5UkuImZnh" />
         </Patch>
       </Node>
       <!--
@@ -11191,6 +11282,8 @@
                   </p:NodeReference>
                   <Pin Id="RiaoAvwXAsyLjpK2BzK0dm" Name="Break" Kind="OutputPin" />
                   <ControlPoint Id="OlO14UaHhR7MctIkUVszXm" Bounds="356,329" Alignment="Top" />
+                  <ControlPoint Id="VkQan7cSqdCL2TUSgU6A4Y" Bounds="439,329" Alignment="Top" />
+                  <ControlPoint Id="SmivlOTnCqiNuyABWRY0FJ" Bounds="439,503" Alignment="Bottom" />
                   <Patch Id="Q9h6uZyKxNyP3vtJNuflNE" ManuallySortedPins="true">
                     <Patch Id="Ro9BjVKeTGzPD6bHSXaNjC" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="UgCEbYV1c7gQSFQYV3jHJd" Name="Update" ManuallySortedPins="true" />
@@ -11236,8 +11329,6 @@
                       <Pin Id="EdMgnhWa3VlMhHdayDgowg" Name="Output" Kind="StateOutputPin" />
                     </Node>
                   </Patch>
-                  <ControlPoint Id="VkQan7cSqdCL2TUSgU6A4Y" Bounds="439,329" Alignment="Top" />
-                  <ControlPoint Id="SmivlOTnCqiNuyABWRY0FJ" Bounds="439,503" Alignment="Bottom" />
                 </Node>
               </Patch>
             </Node>
@@ -11282,7 +11373,7 @@
           <Patch Id="R0n1DSuM79SLpYB36DtFF8" Name="Create" />
           <Patch Id="COQtID4YQRMPhQnjeHwztK" Name="Update">
             <Pin Id="EKRvdX1f42XOoMdUOzLn1C" Name="Input" Kind="InputPin" Bounds="297,95">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -11315,8 +11406,8 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="BRI1by1CrieP2IbgZKHuqq" Location="VL.Skia" Version="2021.4.9" />
-  <NugetDependency Id="Tj9pR4jK7PdLUvUwsqAtdc" Location="VL.Core" Version="2021.4.9" />
-  <NugetDependency Id="BN7vxCsXiyZLLmCMsmdAAt" Location="VL.Lang" Version="2021.4.9" />
+  <NugetDependency Id="BRI1by1CrieP2IbgZKHuqq" Location="VL.Skia" Version="2021.4.12" />
+  <NugetDependency Id="Tj9pR4jK7PdLUvUwsqAtdc" Location="VL.Core" Version="2021.4.12" />
+  <NugetDependency Id="BN7vxCsXiyZLLmCMsmdAAt" Location="VL.Lang" Version="2021.4.12" />
   <PlatformDependency Id="Jv9kUW4hHexQYv8tqnP27D" Location="./lib/netstandard2.0/VL.IO.OSC.dll" />
 </Document>

--- a/VL.IO.OSC.vl
+++ b/VL.IO.OSC.vl
@@ -16,7 +16,7 @@
         <Patch Id="T9m6JYxPsweMGLZTJnbQal" IsGeneric="true">
           <Canvas Id="N7X6BKisllCNVJyesLqJ62" CanvasType="Group">
             <Node Bounds="310,159,65,19" Id="IaQ5YG3QH7wPYszr6oGlb9">
-              <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+              <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="UdpSocket" />
                 <CategoryReference Kind="Category" Name="Socket" />
@@ -29,7 +29,7 @@
             </Node>
             <ControlPoint Id="CG5PaBOuAUYPrgmWoma71h" Bounds="372,198" />
             <Node Bounds="310,99,74,19" Id="VnrtvaurXvIM6tN0csJ0Jo">
-              <p:NodeReference LastCategoryFullName="IO.Net" LastSymbolSource="VL.CoreLib.IO.vl">
+              <p:NodeReference LastCategoryFullName="IO.Net" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="IPEndPoint" />
                 <CategoryReference Kind="Category" Name="Net" />
@@ -39,7 +39,7 @@
               <Pin Id="C2Y3CjSNqiFLSEdzpuivDz" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="310,69,34,19" Id="IST5RNegAyyLVTkZIyA34x">
-              <p:NodeReference LastCategoryFullName="IO.Net.IPAddress" LastSymbolSource="VL.CoreLib.IO.vl">
+              <p:NodeReference LastCategoryFullName="IO.Net.IPAddress" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Any" />
                 <CategoryReference Kind="Category" Name="IPAddress" />
@@ -54,7 +54,7 @@
             <Pad Id="CnJMpcqPjcQMSpoYuQL9pt" Bounds="319,840" />
             <Pad Id="Iq8dvFYRfNHLX5vvxi15Hd" Bounds="312,216" />
             <Node Bounds="278,408,88,26" Id="NHaPJlT7dWHLAOOioXUpF5">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" />
                 <Choice Kind="OperationCallFlag" Name="Create" />
@@ -62,7 +62,7 @@
               <Pin Id="Tm4DYJfUPJrOTJqX1yIyKz" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="278,572,88,26" Id="S3nvcijIMYaP86MIKNvYFf">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="SetAddress" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" NeedsToBeDirectParent="true" />
@@ -72,7 +72,7 @@
               <Pin Id="KNm7NHuuim2QMjIjcKAq6N" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="278,674,88,26" Id="OHurEuZoKAKLPbOGE76pEi">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetBytes" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" NeedsToBeDirectParent="true" />
@@ -82,7 +82,7 @@
               <Pin Id="DrT3OnJo0UzNUADECBUZuq" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="278,631,70,19" Id="EZrNyju8y5XPHrrtLreq7W">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="ArgsToData" />
               </p:NodeReference>
@@ -94,7 +94,7 @@
             <ControlPoint Id="Nt7ZECpKNCbMzCq3uek0rC" Bounds="384,614" />
             <Pad Id="VCySKPT1pCGOeQ3nvO5lyI" Bounds="280,465" />
             <Node Bounds="278,493,88,26" Id="FtzyRGKnPVMP2j9OTp9d9G">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Clear" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" NeedsToBeDirectParent="true" />
@@ -106,7 +106,7 @@
             <ControlPoint Id="Qw20BMssojRQAcM5yOJdvk" Bounds="810,858" />
             <ControlPoint Id="BzSRjxOZ9ItM3vVz0T3ICB" Bounds="862,858" />
             <Node Bounds="689,926,47,19" Id="VTvqyOH8fKQPFn7W3PNyhJ">
-              <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+              <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Sender (Datagram)" />
               </p:NodeReference>
@@ -120,7 +120,7 @@
 
 -->
             <Node Name="ToBundles (Internal)" Bounds="81,1327,810,1341" Id="LXCRcGFGZMiNcziu1z4yrx">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="JIL8PHzhrroPhCSHoHP7Kl">
@@ -129,7 +129,7 @@
                 <ControlPoint Id="E4nBDPpEsPmNWVcGdQBii1" Bounds="591,2651" />
                 <Link Id="U0t6ZvLnhcmLZ3Vg9L8NEH" Ids="E4nBDPpEsPmNWVcGdQBii1,NT5cgzoyFr0LHeNJ920gSK" IsHidden="true" />
                 <Node Bounds="136,1467,607,904" Id="APBcVrh7fj0OnFpykYkc01">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -149,7 +149,7 @@
                     </Patch>
                     <Patch Id="OG1tWuLgBWDQGK0xFhcwHa" Name="Dispose" ManuallySortedPins="true" />
                     <Node Bounds="149,1490,79,26" Id="GXfPkEs8WU0Muu0DznhsOK">
-                      <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastSymbolSource="VL.Collections.vl">
+                      <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="ConcurrentQueue" />
                         <Choice Kind="OperationCallFlag" Name="Count" />
@@ -159,7 +159,7 @@
                       <Pin Id="NrP4i0FURFZN6FywKnmon7" Name="Count" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="223,1534,25,19" Id="HhY2uI58v7VODwchMixGcF">
-                      <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="=" />
                       </p:NodeReference>
@@ -168,7 +168,7 @@
                       <Pin Id="KeZal7IdZKCNdnYaxrpLYD" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="282,1666,449,684" Id="HsaNcdIfkV3MW7CmiyFoL2">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                         <Choice Kind="ApplicationStatefulRegion" Name="If" />
                         <CategoryReference Kind="Category" Name="Primitive" />
@@ -182,12 +182,12 @@
                       <ControlPoint Id="AO3pVJtQYgzMinbCJ2czoW" Bounds="712,1673" Alignment="Top" />
                       <Patch Id="VmI6GAtSZhgOHb4X1vHqir" ManuallySortedPins="true">
                         <Pad Id="IuxM3AnOxDNOJV2dy0mp4p" Comment="Bytes for Message Size" Bounds="419,1759,20,15" ShowValueBox="true" isIOBox="true" Value="4">
-                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="TypeFlag" Name="Integer32" />
                           </p:TypeAnnotation>
                         </Pad>
                         <Node Bounds="295,1714,66,26" Id="LHCPprk16q2PXfLuBEd2oK">
-                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Count" />
                             <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -197,7 +197,7 @@
                           <Pin Id="TAOUVQb8LMiMd6WQxVHSNR" Name="Count" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="387,1778,25,19" Id="AZcLaCQhkUjMElzt9bBWzb">
-                          <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="+" />
                           </p:NodeReference>
@@ -206,7 +206,7 @@
                           <Pin Id="TZd85YXgF73PwXWYwjYytg" Name="Output" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="451,1693,44,26" Id="SFCHxJOExM0QYns7u7jRTw">
-                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Count" />
                             <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -215,7 +215,7 @@
                           <Pin Id="LRk4ADKY2o5LY3ZNsamf2C" Name="Count" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="385,1870,31,19" Id="ICLI3pjhxf9PfikPYBjlHV">
-                          <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="&gt;" />
                           </p:NodeReference>
@@ -226,7 +226,7 @@
                         <Patch Id="QDey7Zd3gdGMA5hZIH1NUA" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="I0QuvTdD3y3MIak5vwgxlf" Name="Then" ParticipatingElements="LHCPprk16q2PXfLuBEd2oK,Lrg9gCNc5ZoPpwDSqjfF8F" ManuallySortedPins="true" />
                         <Node Bounds="388,1932,279,112" Id="MHfJtwRHPi7PrPA5LU1524">
-                          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                             <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                             <Choice Kind="ApplicationStatefulRegion" Name="If" />
                             <FullNameCategoryReference ID="Primitive" />
@@ -240,7 +240,7 @@
                             <Patch Id="BuHi3PPO3ALQYkchiFYRJP" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="IY9MTkAKOt6Pkf7nkN9GsA" Name="Then" ManuallySortedPins="true" />
                             <Node Bounds="401,1980,68,19" Id="DH9PMfLgqmjQRklY1oPcP7">
-                              <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastSymbolSource="VL.IO.OSC.vl">
+                              <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastDependency="VL.IO.OSC.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="StartBundle" />
                               </p:NodeReference>
@@ -248,7 +248,7 @@
                               <Pin Id="O0S9F3aZOzAO306OQ8QlPm" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="589,1989,66,26" Id="BIbyruJQQ1nLi3Ol8y8DZO">
-                              <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                              <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="Add" />
                                 <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -260,7 +260,7 @@
                           </Patch>
                         </Node>
                         <Node Bounds="402,2083,66,26" Id="Lrg9gCNc5ZoPpwDSqjfF8F">
-                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="Count" />
                             <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -270,7 +270,7 @@
                           <Pin Id="HmOApslXHT8LELSJBDTbNw" Name="Count" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="385,1828,25,19" Id="JQOb3SUHsCZQbZbrwc3B7N">
-                          <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="+" />
                           </p:NodeReference>
@@ -279,7 +279,7 @@
                           <Pin Id="VZuUPayDmhjLAO9jze9gcX" Name="Output" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="658,2161,25,19" Id="CC6wibhDqrYNKieDlLqZXz">
-                          <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="+" />
                           </p:NodeReference>
@@ -288,7 +288,7 @@
                           <Pin Id="AOWFCO4OV8iPYQGyvqgFcN" Name="Output" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="688,2290,30,19" Id="THxBUDKX6y5OQNLbAeBzCE">
-                          <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="OR" />
                           </p:NodeReference>
@@ -297,7 +297,7 @@
                           <Pin Id="FDho3ptySRGOtI7yjJQZpK" Name="Output" Kind="StateOutputPin" />
                         </Node>
                         <Node Bounds="402,2253,66,26" Id="GzMGzWMyiW6QcWdRJR6FIS">
-                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="AddRange" />
                             <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -307,7 +307,7 @@
                           <Pin Id="OJsHIyVOszjPUAEnV3a0et" Name="Output" Kind="StateOutputPin" />
                         </Node>
                         <Node Bounds="402,2213,66,26" Id="Avavp6AwyB6NQjAhkmzoRp">
-                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                          <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="AddRange" />
                             <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -317,7 +317,7 @@
                           <Pin Id="TNoFmvurfAkM5xZEufS3MX" Name="Output" Kind="StateOutputPin" />
                         </Node>
                         <Node Bounds="450,2158,81,19" Id="OC41QaBQg9tO4dOYfUrki1">
-                          <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                          <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="PackInteger32" />
                           </p:NodeReference>
@@ -325,7 +325,7 @@
                           <Pin Id="EZWTR1EQnHTOnIX5lb4vyO" Name="Output" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="658,2218,25,19" Id="QqGgQANgGBmQXSzZ8WORH3">
-                          <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="&gt;" />
                           </p:NodeReference>
@@ -337,7 +337,7 @@
                     </Node>
                     <ControlPoint Id="Bmv2dMyrnVQQMe8cWtDPOh" Bounds="225,1574" />
                     <Node Bounds="148,1588,79,26" Id="FLhXE5j0mTtMqbnCKqiXzB">
-                      <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastSymbolSource="VL.Collections.vl">
+                      <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="TryDequeue" />
                       </p:NodeReference>
@@ -349,7 +349,7 @@
                   </Patch>
                 </Node>
                 <Pad Id="OKLewgggmn2NhTCXylb26H" Comment="Iteration Count" Bounds="97,1427,35,15" ShowValueBox="true" isIOBox="true" Value="999">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Integer32" />
                   </p:TypeAnnotation>
                 </Pad>
@@ -360,7 +360,7 @@
                 <Link Id="EDUpBwOzP5vPvfbDtcCHf1" Ids="RVo4dfyNPMGMMySX8ucOIS,E5ASyQTug35LxqVkCzngHz" />
                 <Link Id="I5s35okMr1lOfMsje9otzm" Ids="KeZal7IdZKCNdnYaxrpLYD,Bmv2dMyrnVQQMe8cWtDPOh" />
                 <Node Bounds="289,1422,68,19" Id="QNuXMUaBLOjMybfec6vcEO">
-                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="StartBundle" />
                   </p:NodeReference>
@@ -411,14 +411,14 @@
                 <Link Id="E7KrbMaTRyhOmaYenEOu1a" Ids="AO3pVJtQYgzMinbCJ2czoW,Dv8T1NdGFzgNsbojaLZfg4" />
                 <Link Id="Ao8dBHTm3OnLEroLIbrQYW" Ids="QOfyO3KvQyoLrNIUy6qDpp,AO3pVJtQYgzMinbCJ2czoW" />
                 <Pad Id="SgmgZGctPuUP9SOCtDkHDp" Comment="Bundle Size Exceeded" Bounds="712,1434,40,15" ShowValueBox="true" isIOBox="true">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
                 <Link Id="PkN5kEzzWBhNEWnpXJFOxO" Ids="SgmgZGctPuUP9SOCtDkHDp,QOfyO3KvQyoLrNIUy6qDpp" />
                 <Link Id="LRb37XZaCdTMT7LaMd1bDv" Ids="IKBXz5OGp5EMH1efJ6zPEd,MYeJDgv6RPGLKr2ElRrimj" />
                 <Node Bounds="589,2491,229,124" Id="H0bAwCl8qF6QTQjO4ChID9">
-                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="OperationCallFlag" Name="Where" />
                     <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -433,7 +433,7 @@
                     <ControlPoint Id="CB8i5YlAbeONSy5Ui2n8P8" Bounds="681,2500" />
                     <ControlPoint Id="VLnm3K9KXtDLxnIo0plCo8" Bounds="604,2608" />
                     <Node Bounds="601,2523,44,19" Id="KDdKtgIRO9SMGMr9z6r8dw">
-                      <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                      <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Count" />
                         <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -442,7 +442,7 @@
                       <Pin Id="ODcyCJDcz44PrJn6o9cuoq" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="602,2561,25,19" Id="LoZcQEhVNdsLEhd5jnrCuV">
-                      <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="&gt;" />
                       </p:NodeReference>
@@ -451,7 +451,7 @@
                       <Pin Id="It05PfIqihwML2PYupONZy" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Pad Id="TvM6rBS42nBLQpZWSwCNsx" Comment="Empty Bundle Size" Bounds="666,2552,35,15" ShowValueBox="true" isIOBox="true" Value="16">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Integer32" />
                       </p:TypeAnnotation>
                     </Pad>
@@ -466,7 +466,7 @@
                 <Link Id="MSKk22tLNL3Qcwbj09nwCr" Ids="P0h1eil6nm8QL3opCFaOxk,GYqZCqFRPKQPr0yMbPcH10" />
                 <Link Id="RAN5FImtpYgOkVSeup2ITd" Ids="It05PfIqihwML2PYupONZy,VLnm3K9KXtDLxnIo0plCo8" />
                 <Node Bounds="589,2429,66,26" Id="Aph4uToA1ocLGOut8XEUqU">
-                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
                     <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -492,7 +492,7 @@
                 <Pin Id="ALFRocYxWUiPBctw900hrL" Name="Items" Kind="InputPin" Bounds="1723,1443" />
                 <Pin Id="QiCmG1mlBdmM6x1VoY4bgk" Name="TimeTag" Kind="InputPin" Bounds="638,1345" />
                 <Pin Id="BsaeSxZDZxuOUfHSi2cFvH" Name="Maximum Bundle Size" Kind="InputPin" DefaultValue="1024">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Integer32" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -501,7 +501,7 @@
               </Patch>
             </Node>
             <Node Bounds="731,753,64,19" Id="P08jN0JuWbKPp3Zcmaz2Aa">
-              <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="ToBundles" />
               </p:NodeReference>
@@ -517,12 +517,12 @@
 
 -->
             <Node Name="StartBundle (Internal)" Bounds="979,1266,197,184" Id="HAeU7KyE2pHLyBrQ3m010u">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="Rh8OnHPP0yDMDbWOIjonBl">
                 <Node Bounds="991,1381,66,26" Id="SPK2UzioqyCMGQTETuDRhn">
-                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="AddRange" />
                     <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -533,12 +533,12 @@
                   <Pin Id="O9I8Ff4Qiq0QCMQc3QFy4i" Name="Items 2" Kind="InputPin" />
                 </Node>
                 <Pad Id="IlFThZ5O00nLsyHubhEVM2" Comment="" Bounds="1024,1294,46,15" ShowValueBox="true" isIOBox="true" Value="#bundle">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
                 <Node Bounds="1022,1325,64,19" Id="Sdhh53kj3u8PjWoWTxNIMP">
-                  <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationNode" Name="PackString" />
                   </p:NodeReference>
@@ -558,7 +558,7 @@
               </Patch>
             </Node>
             <Node Bounds="731,879,77,19" Id="QtnxyNc6AMMNjb4yCwEHax">
-              <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+              <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ToDatagrams" />
               </p:NodeReference>
@@ -568,7 +568,7 @@
               <Pin Id="JXyMDxYTBkLMxQIuKPa4ts" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="731,824,79,19" Id="F4uOcquQteyL0AvYCujNRY">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ToObservable (Sequence)" />
               </p:NodeReference>
@@ -578,7 +578,7 @@
             </Node>
             <ControlPoint Id="I8mP8Fxgpj3QRaIpqjLvHE" Bounds="792,795" />
             <Node Bounds="427,877,103,80" Id="UzLZlJD4YkePo8aquylSaD">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -588,7 +588,7 @@
                 <Patch Id="UHZbVSjzHU7MlcK29jO9Yg" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="LWen4hR0NZzM4QAgKbHC8S" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="439,906,79,26" Id="Q7NOVrb8BbCN9qqiAbxwd9">
-                  <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Enqueue" />
                     <CategoryReference Kind="ClassType" Name="ConcurrentQueue" NeedsToBeDirectParent="true" />
@@ -601,7 +601,7 @@
             </Node>
             <ControlPoint Id="QtdWEP8GG79NUSJ1QNcH6D" Bounds="426,715" />
             <Node Bounds="115,796,37,19" Id="FNA9CCckJ42QGTxACD87jr">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="NOT" />
               </p:NodeReference>
@@ -609,7 +609,7 @@
               <Pin Id="REtPl7Sdel9LhdbKKsVDQ9" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="121,872,145,135" Id="N5sSaVlknGhN4dbZ0PcO3F">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -619,7 +619,7 @@
                 <Patch Id="OtRY1ec4D0gPNaxDBH8oDw" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="JyXtUF6oa4NMjc8Nvmyuka" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="175,895,72,19" Id="BxSTVUm1Uc5MA91asQrEFW">
-                  <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+                  <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ToDatagram" />
                   </p:NodeReference>
@@ -629,7 +629,7 @@
                   <Pin Id="TS9com8rGSnQPhU09PMU5Z" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="133,968,47,19" Id="MftR0JKyAYAPA23imKaBYJ">
-                  <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+                  <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Sender (Datagram)" />
                   </p:NodeReference>
@@ -637,14 +637,14 @@
                   <Pin Id="DZSjETJNnFwQB8WxJnjUII" Name="Datagrams" Kind="InputPin" />
                 </Node>
                 <Node Bounds="175,931,79,19" Id="Q6V5YncQY58NBN47XXoTy7">
-                  <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ToObservable" />
                     <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
                   <Pin Id="BOSe5SxrOeNNx2SnqsiYVN" Name="Message" Kind="InputPin" />
                   <Pin Id="DEVKph6VMpNOM949t9TLiK" Name="Send" Kind="InputPin" DefaultValue="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -660,7 +660,7 @@
             <Pad Id="TiwhDmGrDLLOywVIbQXrIR" Bounds="1338,710" />
             <Pad Id="JVjpzsAGtELPi8V6vLTxDY" Bounds="1365,709" />
             <Node Bounds="969,392,338,439" Id="N80jIdHGF6JPqy9pJvgk7O">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -672,7 +672,7 @@
                 <Patch Id="IYzgfx9CulyOjlERCBDiYY" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="GwboiQy06aWNTdDjYfwNVi" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="1028,400,114,110" Id="LJxcVgWomaGQGKDsbkNp1g">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationFlag" Name="ForEach" />
                     <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
@@ -686,7 +686,7 @@
                     <Patch Id="OW9de05PUqwNq7fPXHcJ0t" Name="Update" ManuallySortedPins="true" />
                     <Patch Id="CZqynaCrou5Mzrp5ypkfCk" Name="Dispose" ManuallySortedPins="true" />
                     <Node Bounds="1049,438,79,26" Id="D1I3K3hKvTKLTKBfSwD0Bq">
-                      <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastSymbolSource="VL.Collections.vl">
+                      <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Enqueue" />
                         <CategoryReference Kind="ClassType" Name="ConcurrentQueue" NeedsToBeDirectParent="true" />
@@ -698,7 +698,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="1112,533,64,19" Id="IEtIEFVAVylMdkZfubsx4i">
-                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCClient" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToBundles" />
                   </p:NodeReference>
@@ -709,7 +709,7 @@
                   <Pin Id="B99ebQe6JJqLKMElPwZCPP" Name="Bundle Size Exceeded" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1074,803,47,19" Id="EBl7Ma26axsOoEb9E7MRSc">
-                  <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+                  <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Sender (Datagram)" />
                   </p:NodeReference>
@@ -717,7 +717,7 @@
                   <Pin Id="PJj87u5vEp4M3XygmSsvBs" Name="Datagrams" Kind="InputPin" />
                 </Node>
                 <Node Bounds="1116,756,77,19" Id="PQtVlpGUJLWOh26xJjPGD8">
-                  <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+                  <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ToDatagrams" />
                   </p:NodeReference>
@@ -727,7 +727,7 @@
                   <Pin Id="FRPztbiocS6Mukm6VLMlku" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1113,661,79,19" Id="CiOYe0HbQm9OEs5wBIH3RL">
-                  <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ToObservable (Sequence)" />
                   </p:NodeReference>
@@ -739,7 +739,7 @@
             </Node>
             <ControlPoint Id="GPAkSO5ZVF1MWLy3BcMmza" Bounds="971,353" />
             <Node Bounds="-322,590,88,26" Id="KlNpVxSxDlRLc2AVkyC7T6">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="SetAddress" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" NeedsToBeDirectParent="true" />
@@ -750,7 +750,7 @@
             </Node>
             <ControlPoint Id="Cet082KsSe0L9vu950dL0O" Bounds="-237,570" />
             <Node Bounds="-322,511,88,26" Id="IEPvdOGwUpvOwVgAhYdMli">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Clear" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" NeedsToBeDirectParent="true" />
@@ -763,7 +763,7 @@
             <Pad Id="SKuEADGVjimMEiUpAWccjV" Bounds="-308,831" />
             <Pad Id="PVwnDn7POjCLGycvwaLfGY" Bounds="-281,830" />
             <Node Bounds="-322,664,88,26" Id="EdYFa4NMjiXMshmNWgGTpT">
-              <p:NodeReference>
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetBytes" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" NeedsToBeDirectParent="true" />
@@ -773,7 +773,7 @@
               <Pin Id="ICxMq44VYSsLvxjyBM83dW" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="-176,788,103,80" Id="Vw3KjWgNyQDMSQRFasLNn6">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -783,7 +783,7 @@
                 <Patch Id="DSQ8F14YRTIOkMnni2tQ6Z" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="GntnSo2n0qpMuxaJQ5rD7e" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="-164,817,79,26" Id="CIov7jQRFouQMnLrZ1X225">
-                  <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Concurrent.ConcurrentQueue" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Enqueue" />
                     <CategoryReference Kind="ClassType" Name="ConcurrentQueue" NeedsToBeDirectParent="true" />
@@ -796,7 +796,7 @@
             </Node>
             <ControlPoint Id="IdgAdGBS7ieQHaBvpMG5Sl" Bounds="-174,705" />
             <Node Bounds="-508,780,37,19" Id="KPxignxgQLqPH9jmYzPabL">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="NOT" />
               </p:NodeReference>
@@ -804,7 +804,7 @@
               <Pin Id="OsqS276mOauPOgxOy92jcs" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="-479,862,145,135" Id="RtLYWkhuJOgPFVLwk9hhep">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -814,7 +814,7 @@
                 <Patch Id="S3CAnd3NBMvPakgxnhsTHE" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="HVEEPsF5dIjOnvE07EnlfH" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="-425,885,72,19" Id="CoXh7tX7vJqOV2uJiwFDb1">
-                  <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+                  <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ToDatagram" />
                   </p:NodeReference>
@@ -824,7 +824,7 @@
                   <Pin Id="BJ6SHiTTKEOMaFjJkfXhEC" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="-467,958,47,19" Id="MHzZtJCYDRjPL16Hq1V6Ee">
-                  <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+                  <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Sender (Datagram)" />
                   </p:NodeReference>
@@ -832,14 +832,14 @@
                   <Pin Id="GEPuuJVh1PxPa90TEGZrzY" Name="Datagrams" Kind="InputPin" />
                 </Node>
                 <Node Bounds="-425,921,79,19" Id="LaDt9OwA7zAPoHOJ4ECefd">
-                  <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ToObservable" />
                     <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
                   <Pin Id="Juvzc3lj8i8NWbMUJfyaUo" Name="Message" Kind="InputPin" />
                   <Pin Id="NrIyU5dquZeLWvMqQLiy9b" Name="Send" Kind="InputPin" DefaultValue="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -848,7 +848,7 @@
               </Patch>
             </Node>
             <Node Bounds="-492,827" Id="Lx671Yad7s5Ps8BXNoOj7g">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
               </p:NodeReference>
@@ -858,7 +858,7 @@
             </Node>
             <ControlPoint Id="UoUxwNiqmYtQbPKbzl8XBi" Bounds="-394,725" />
             <Node Bounds="-176,757,37,19" Id="OEg6nRFq74tPEBNkYDY6Oh">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
               </p:NodeReference>
@@ -867,7 +867,7 @@
               <Pin Id="MXZjqRrdflwOO2hvfSNvak" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Node Bounds="118,835" Id="T006sBcEMXKPf9AMMOnEIO">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
               </p:NodeReference>
@@ -877,7 +877,7 @@
             </Node>
             <ControlPoint Id="Kh4GCs6TLMtM9lFBkDsME4" Bounds="217,796" />
             <Node Bounds="420,839,37,19" Id="EOso1avzAk3Pii9M0cUdna">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
               </p:NodeReference>
@@ -887,7 +887,7 @@
             </Node>
             <Overlay Id="BngNRzWAxXrPHDU62w1514" Name="Bundling" Bounds="627,311,848,674" />
             <Node Bounds="760,453,62,26" Id="SfJfS6i5KxiO0Iq7ZUFcdQ">
-              <p:NodeReference LastCategoryFullName="IO.OSC.OSCTimeTag" LastSymbolSource="OSC.Core.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC.OSCTimeTag" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationNode" Name="Pack" />
                 <CategoryReference Kind="Category" Name="OSCTimeTag" />
@@ -896,7 +896,7 @@
               <Pin Id="NO26EnW1GaMM7lBEgdrsJ5" Name="Bytes" Kind="OutputPin" />
             </Node>
             <Node Bounds="760,413,62,26" Id="VMXTzamGa8hNzqSxtjs1nV">
-              <p:NodeReference LastCategoryFullName="Main.OSCTimeTag" LastSymbolSource="NewOSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC.OSCTimeTag" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationNode" Name="Create" />
                 <CategoryReference Kind="Category" Name="OSCTimeTag" />
@@ -905,7 +905,7 @@
               <Pin Id="MtCZqNkdzf8QPxtzuTThxB" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="760,378,36,19" Id="KfoKZS9f432QDe623xQQgC">
-              <p:NodeReference LastCategoryFullName="System.DateTime" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="System.DateTime" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationNode" Name="Now" />
                 <CategoryReference Kind="Category" Name="DateTime" />
               </p:NodeReference>
@@ -1035,17 +1035,17 @@
           <Patch Id="LQDhm8l8hswOi3TdetvBNs" Name="Create (Internal)" ParticipatingElements="IST5RNegAyyLVTkZIyA34x,NHaPJlT7dWHLAOOioXUpF5" />
           <Patch Id="CAw4X3LIAUdNnaE42FLkgm" Name="Update (Internal)" ManuallySortedPins="true">
             <Pin Id="LcwJPFidbUzNbLUQCOfpSB" Name="Server" Kind="InputPin" DefaultValue="127.0.0.1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="JdrAhx92cbSNIn4VmgbE63" Name="Port" Kind="InputPin" DefaultValue="4444">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="HeyRNQLIifPPZfL88RhJ3l" Name="Maximum Bundle Size" Kind="InputPin" DefaultValue="1024">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
@@ -1057,7 +1057,7 @@
             <Pin Id="G5OBDnvwQqOLbCcdS6shsk" Name="Address" Kind="InputPin" />
             <Pin Id="HFWr0A6uxDbMyjE5xjXMrk" Name="Arguments" Kind="InputPin" />
             <Pin Id="C9DpmWVJkBqMHXDbN5mOwH" Name="Bundled Per Frame" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
@@ -1067,7 +1067,7 @@
             <Pin Id="UVR1GzRanPkLh6ko0WHXbV" Name="Input" Kind="InputPin" />
             <Pin Id="DuOYEmn7ggqQGJa8wGMocx" Name="Maximum Bundle Size" Kind="InputPin" />
             <Pin Id="ThtZypsbLuzNR0phPGzShh" Name="Apply" Kind="InputPin" Bounds="973,349" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
@@ -1077,7 +1077,7 @@
           <Patch Id="KrZhaurhIJTQSjudAsVN16" Name="SendMessage (Empty)" ManuallySortedPins="true">
             <Pin Id="Ul4MOgI0DoyOC3h1WPUmzy" Name="Address" Kind="InputPin" />
             <Pin Id="J9Aqeo3IgdLLL4VTzsXTDf" Name="Bundled Per Frame" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
@@ -1097,8 +1097,8 @@
         </p:NodeReference>
         <Patch Id="DBYffVoBvvYNT5aVDQ8qBo">
           <Canvas Id="TZur7bWUCCrOI97ofLK6rM" CanvasType="Group">
-            <Node Bounds="345,138,63,19" Id="MckEAQD2AwhLO4gFqpHFLU">
-              <p:NodeReference LastCategoryFullName="IO.Socket" LastSymbolSource="VL.CoreLib.IO.vl">
+            <Node Bounds="345,138,65,19" Id="MckEAQD2AwhLO4gFqpHFLU">
+              <p:NodeReference LastCategoryFullName="IO.Socket" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="UdpServer (Reactive)" />
               </p:NodeReference>
@@ -1110,14 +1110,14 @@
               <Pin Id="Us7OQ22VvnbQJbD6g0suI0" Name="Is Open" Kind="OutputPin" />
             </Node>
             <Node Bounds="345,194,91,19" Id="Q4IrELTKVUiNXUtW3OyjWB">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ToOSCMessages (Reactive)" />
               </p:NodeReference>
               <Pin Id="EyGsKPlMfE8Lo67SywVPo7" Name="Input" Kind="InputPin" />
               <Pin Id="McD0rxChkpRLOYuk7MplTj" Name="Result" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="D194eFIpaTxLntHnVFzUNp" Bounds="354,-102" />
+            <ControlPoint Id="D194eFIpaTxLntHnVFzUNp" Bounds="355,-149" />
             <ControlPoint Id="BCfKr0FAjAmNdA5kaC55Xd" Bounds="443,85" />
             <ControlPoint Id="SEUIGacq9XOMfaEz2wRBbA" Bounds="507,85" />
             <ControlPoint Id="OteLumLIkpbMYD7BtxsvPt" Bounds="414,176" />
@@ -1126,7 +1126,7 @@
             <ControlPoint Id="GwwsLWW4aqWOYtfP5AjF0D" Bounds="620,258" />
             <ControlPoint Id="GWgDurXIPFHMIXu7UxUMLA" Bounds="444,1154" />
             <Node Bounds="788,440,36,19" Id="T2fIC60d19cMK2L9ALk3TY">
-              <p:NodeReference LastCategoryFullName="System.DateTime" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="System.DateTime" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Now" />
                 <CategoryReference Kind="RecordType" Name="DateTime" NeedsToBeDirectParent="true" />
@@ -1135,19 +1135,19 @@
             </Node>
             <ControlPoint Id="RgQkpHUeMSRLNZ4KWJ5RMK" Bounds="170,279" />
             <Node Bounds="308,300,381,830" Id="AJ6bR2VGmCYNn6X5pSe5WZ">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:NodeReference>
               <Pin Id="IxclsB3L41TMavCRK6zGq5" Name="Condition" Kind="InputPin" />
               <ControlPoint Id="A6ONwD8W82SL47Yje7lagQ" Bounds="444,1124" Alignment="Bottom" />
-              <ControlPoint Id="T2domR7aeKmNXpWUjBxNz8" Bounds="404,600" Alignment="Top" />
+              <ControlPoint Id="T2domR7aeKmNXpWUjBxNz8" Bounds="404,306" Alignment="Top" />
               <Patch Id="FvlYqnkJK72MRp91kHFNiL" ManuallySortedPins="true">
                 <Patch Id="IdVf5s2C3omNHrG4VhecjD" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="H9k5r0droSbQambIFa8Q1m" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="413,647,81,26" Id="Pkq5h4PSvOCLy6052R480e">
-                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Keys" />
                     <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
@@ -1157,7 +1157,7 @@
                   <Pin Id="EWovMag55DvOAMGeCemW26" Name="Keys" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="401,778,276,332" Id="UmagpLzXrJPMVviasqHDuh">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -1170,7 +1170,7 @@
                     <Patch Id="HBMhqqi3krhOxp80VAEtQ8" Name="Update" ManuallySortedPins="true" />
                     <Patch Id="UugAnN4D65NLhEJ9ZpSKYE" Name="Dispose" ManuallySortedPins="true" />
                     <Node Bounds="413,819,81,26" Id="Q7TssEXfuS1LmEI4gQeOkv">
-                      <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastSymbolSource="VL.Collections.vl">
+                      <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="TryGetValue" />
                         <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
@@ -1182,7 +1182,7 @@
                       <Pin Id="OrfH2BpwvGmOJgrAON4hKX" Name="Value" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="469,874,196,154" Id="VWLw9KLwt3XLU9Az5fQN7A">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                         <Choice Kind="ApplicationStatefulRegion" Name="If" />
                         <CategoryReference Kind="Category" Name="Primitive" />
@@ -1196,7 +1196,7 @@
                         <Patch Id="SU5Y6L9tttmMTQzOGCA0ay" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="V2kVS9wWMq4MkqI98JlSXf" Name="Then" ManuallySortedPins="true" />
                         <Node Bounds="481,959,62,26" Id="FvfpJz3eNFENkfG163co1Q">
-                          <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                          <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="RecordType" Name="OSCMessage" />
                             <Choice Kind="OperationCallFlag" Name="Split" />
@@ -1206,8 +1206,8 @@
                           <Pin Id="EvJadkfTk0NNg0ruOAEgwJ" Name="TypeTags" Kind="OutputPin" />
                           <Pin Id="FCNVdCcnZw5ND9pcB0r2vC" Name="Arguments" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="485,904,70,26" Id="RGFLAhMNxHTN2DSxpDZirb">
-                          <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                        <Node Bounds="485,904,70,19" Id="RGFLAhMNxHTN2DSxpDZirb">
+                          <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="RecordType" Name="ValueTuple (2 Items)" />
                             <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -1217,7 +1217,7 @@
                           <Pin Id="K5sPIkDHwnhOrn4BRSrya1" Name="Item 2" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="561,943,25,19" Id="OugHeimwp1wLW26y3AOLY4">
-                          <p:NodeReference LastCategoryFullName="System.DateTime" LastSymbolSource="CoreLibBasics.vl">
+                          <p:NodeReference LastCategoryFullName="System.DateTime" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="-" />
                             <CategoryReference Kind="RecordType" Name="DateTime" NeedsToBeDirectParent="true" />
@@ -1237,7 +1237,7 @@
                       </Patch>
                     </Node>
                     <Node Bounds="442,1055,45,19" Id="CUzglKk15gFN4JU59WRzsr">
-                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Cons" />
                         <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1249,8 +1249,8 @@
                     </Node>
                   </Patch>
                 </Node>
-                <Node Bounds="475,731,41,26" Id="RMKbVUKDKiVO8oTeZkFCw0">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <Node Bounds="475,731,41,19" Id="RMKbVUKDKiVO8oTeZkFCw0">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Sort" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1259,8 +1259,8 @@
                   <Pin Id="Rm2mAoWDOTuNKFWlKi40nL" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="H2WWG9ZHfv3LMqW23agL6i" Name="Apply" Kind="InputPin" />
                 </Node>
-                <Node Bounds="490,686,83,26" Id="IvlDHH2XD6uOyqZQGT4dad">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <Node Bounds="490,686,83,19" Id="IvlDHH2XD6uOyqZQGT4dad">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="FromSequence" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1269,7 +1269,7 @@
                   <Pin Id="D8z5hK2qlEnNYrRp7BXuJg" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="395,323,53,19" Id="VsEawMkDt9qOV2Q1WvCfPN">
-                  <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                  <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                     <Choice Kind="ProcessAppFlag" Name="Sampler" />
@@ -1279,7 +1279,7 @@
                   <Pin Id="OxDfi01LpVXPElw2wDLXXC" Name="On Data" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="331,381,263,238" Id="Fx9qV2UbKRcPfh0m2uIL9n">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <FullNameCategoryReference ID="Primitive" />
@@ -1293,21 +1293,21 @@
                     <Patch Id="AQHyiWJLuS6NW6cDN3AgBN" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="UqmHG1fxx4kNf7X5zBrbve" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="383,447,192,140" Id="FeBOXlhTLOjNO7J2xsWqZ2">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                         <Choice Kind="ApplicationFlag" Name="ForEach" />
                         <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
                       </p:NodeReference>
                       <Pin Id="OdBaPo24mV2NecmsJe4qXP" Name="Break" Kind="OutputPin" />
-                      <ControlPoint Id="UhzMqhwnJEGOEq4ZFAthvN" Bounds="397,454" Alignment="Top" />
-                      <ControlPoint Id="DqSHOtilPoLMW4RycwI9Xe" Bounds="424,454" Alignment="Top" />
+                      <ControlPoint Id="UhzMqhwnJEGOEq4ZFAthvN" Bounds="397,453" Alignment="Top" />
+                      <ControlPoint Id="DqSHOtilPoLMW4RycwI9Xe" Bounds="424,453" Alignment="Top" />
                       <ControlPoint Id="Hw90uzKmtAAOG0wOWTQDAK" Bounds="425,581" Alignment="Bottom" />
                       <Patch Id="OzP13jTwAXoM35XFk8Mtin" ManuallySortedPins="true">
                         <Patch Id="Dhw6uNgjdxwLi7X7tZfs7a" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="SMEdAdS7s3XO9h7zchH1mu" Name="Update" ManuallySortedPins="true" />
                         <Patch Id="Jm2VODGXYnmOOVXCY4f7N9" Name="Dispose" ManuallySortedPins="true" />
                         <Node Bounds="423,525,81,26" Id="Q36YmmkgmjuQUzHYbxKz09">
-                          <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastSymbolSource="VL.Collections.vl">
+                          <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
                             <Choice Kind="OperationCallFlag" Name="SetItem" />
@@ -1317,8 +1317,8 @@
                           <Pin Id="VgPMRMZhEpHLavD6wdGgan" Name="Value" Kind="InputPin" />
                           <Pin Id="RWKAPCWrgh8L3lnSPzCmdY" Name="Output" Kind="StateOutputPin" />
                         </Node>
-                        <Node Bounds="493,474,70,26" Id="JuMbD7ccmDuNmKb0raHp93">
-                          <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                        <Node Bounds="493,474,70,19" Id="JuMbD7ccmDuNmKb0raHp93">
+                          <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="RecordType" Name="ValueTuple (2 Items)" />
                             <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -1328,7 +1328,7 @@
                           <Pin Id="NiLc9TE0XekM1VUnbwHEiI" Name="Output" Kind="StateOutputPin" />
                         </Node>
                         <Node Bounds="403,480,62,26" Id="LOJHVVPYlF1PWSZaT5uMeg">
-                          <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                          <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="RecordType" Name="OSCMessage" />
                             <Choice Kind="OperationCallFlag" Name="Split" />
@@ -1341,7 +1341,7 @@
                       </Patch>
                     </Node>
                     <Node Bounds="395,404,47,19" Id="TCcptjWaTENQDBrPopOcEL">
-                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Flatten" />
                       </p:NodeReference>
@@ -1351,7 +1351,7 @@
                   </Patch>
                 </Node>
                 <Node Bounds="544,330,81,26" Id="PLS6TO76GNxNMhnBSfCz2d">
-                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Clear" />
                     <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
@@ -1363,83 +1363,102 @@
               </Patch>
             </Node>
             <ControlPoint Id="Ewzj4L0E9U6OYAXMS2ezDh" Bounds="703,600" />
-            <Node Bounds="303,-88,45,19" Id="AAXhpA1eDljMBcjjqjRusi">
-              <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="Split (String)" />
-              </p:NodeReference>
-              <Pin Id="RZ6nTtNAwQ8On0V7ZcenOJ" Name="Input" Kind="StateInputPin" />
-              <Pin Id="E9ztDNfuakBM7t1POIYEki" Name="Separator" Kind="InputPin" DefaultValue="." />
-              <Pin Id="LPziGEfQE9HNedUVYwRp6N" Name="Options" Kind="InputPin" />
-              <Pin Id="J8aZnWHx591NZ4zbZ6CLNv" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <Node Bounds="303,-59,41,26" Id="TIqyl1p53lPOlApAswkaUx">
-              <p:NodeReference LastCategoryFullName="VL.Lib.Collections.Spread" LastSymbolSource="VL.Core.dll">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="AssemblyCategory" Name="Spread" NeedsToBeDirectParent="true" />
-                <Choice Kind="OperationCallFlag" Name="First" />
-              </p:NodeReference>
-              <Pin Id="TOeIUe7AQMoLhbCOBe7uqv" Name="Input" Kind="StateInputPin" />
-              <Pin Id="SawQaa3S6qbLeCMoyza30H" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="265,-24,55,19" Id="JaVCQXtsCXWOU92tcYGHme">
-              <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="TryParse" />
-              </p:NodeReference>
-              <Pin Id="F3qOUBvEhZFMYJWjfJjoVA" Name="String" Kind="InputPin" />
-              <Pin Id="N2lQ5bKtEZOPMds4nF3kaI" Name="Value" Kind="OutputPin" />
-              <Pin Id="CipbFrhHbjpLWwDAUk43Ss" Name="Success" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="233,20,31,19" Id="MUV0qLKDcExO6Afx88BP9N">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="&lt;=" />
-              </p:NodeReference>
-              <Pin Id="SVnKISeDInoQKM2gmodVdE" Name="Input" Kind="InputPin" />
-              <Pin Id="FXJeTatbaq8M6Ksz95Nonm" Name="Input 2" Kind="InputPin" />
-              <Pin Id="ILQdnZ67z4IQBpfVRwdVp7" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="271,19,31,19" Id="VelRAA2DbhQLMrRuJfzrYF">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="&lt;=" />
-              </p:NodeReference>
-              <Pin Id="B54ifXlmTEGQMLNC3GsIDi" Name="Input" Kind="InputPin" />
-              <Pin Id="Rs5hfOJ9V89P4Je9ji4s3N" Name="Input 2" Kind="InputPin" />
-              <Pin Id="CWMzOV4bXL9NZRVTlPMDne" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Pad Id="Qxvu5h0z7v3QT1yEtY2cZ6" Bounds="204,3,35,15" ShowValueBox="true" isIOBox="true" Value="224">
-              <p:TypeAnnotation>
-                <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
+            <Node Bounds="179,-130,227,237" Id="Js7OwCL9YmtLapATy1AQAD">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Primitive" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Pad Id="Tew9Bi8xHB9Qbne09BXUpm" Bounds="299,5,35,15" ShowValueBox="true" isIOBox="true" Value="239">
-              <p:TypeAnnotation>
-                <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
-                <CategoryReference Kind="Category" Name="Primitive" />
-              </p:TypeAnnotation>
-            </Pad>
-            <Node Bounds="233,52,43,19" Id="AmozmPGHg3zNUeKfiJSjL8">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="AND" />
+                <Choice Kind="ProcessStatefulRegion" Name="Cache" />
               </p:NodeReference>
-              <Pin Id="E3Dx6S3dz6gP4ruiqMMygT" Name="Input" Kind="StateInputPin" />
-              <Pin Id="GJPVH3NtCKFPh6tqixHuqh" Name="Input 2" Kind="InputPin" />
-              <Pin Id="C2OR3i0ZA09P4KKBX6eTyC" Name="Output" Kind="StateOutputPin" />
-            </Node>
-            <Node Bounds="316,79,77,19" Id="HvFAniANGlpNZq5cML5Uiq">
-              <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="SwitchOutput" />
-              </p:NodeReference>
-              <Pin Id="JL7c2AGaqGiMSBPfJ72zvD" Name="Condition" Kind="InputPin" />
-              <Pin Id="JHqbUzxGsXNNAHDu4sk4HL" Name="Input" Kind="InputPin" />
-              <Pin Id="ILoQd4g4IGxMZJbsemSZll" Name="Default" Kind="InputPin" DefaultValue="0.0.0.0" />
-              <Pin Id="RuDm93rPkNAOLblVLOwmQx" Name="True" Kind="OutputPin" />
-              <Pin Id="Mj73JmmQokTQaC7V1tfqnJ" Name="False" Kind="OutputPin" />
+              <Pin Id="AaX9dPemQOUNH1iSbJCDn3" Name="Force" Kind="InputPin" />
+              <Pin Id="BBhLLItukIvPmkWkt8SXxE" Name="Dispose Cached Outputs" Kind="InputPin" />
+              <Pin Id="RT2wQipvqb8QT1RSKlOnNj" Name="Has Changed" Kind="OutputPin" />
+              <Patch Id="RiewYKH7JsrPJw0JRuT5PU" ManuallySortedPins="true">
+                <Patch Id="FQlm3BTmOi0L6ZUaDD8YTu" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="E9agL61pKCWMIfdUCj72uB" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="304,-106,45,19" Id="AAXhpA1eDljMBcjjqjRusi">
+                  <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Split (String)" />
+                  </p:NodeReference>
+                  <Pin Id="RZ6nTtNAwQ8On0V7ZcenOJ" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="E9ztDNfuakBM7t1POIYEki" Name="Separator" Kind="InputPin" DefaultValue="." />
+                  <Pin Id="LPziGEfQE9HNedUVYwRp6N" Name="Options" Kind="InputPin" />
+                  <Pin Id="J8aZnWHx591NZ4zbZ6CLNv" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="266,-42,55,19" Id="JaVCQXtsCXWOU92tcYGHme">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="TryParse" />
+                  </p:NodeReference>
+                  <Pin Id="F3qOUBvEhZFMYJWjfJjoVA" Name="String" Kind="InputPin" />
+                  <Pin Id="N2lQ5bKtEZOPMds4nF3kaI" Name="Value" Kind="OutputPin" />
+                  <Pin Id="CipbFrhHbjpLWwDAUk43Ss" Name="Success" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="234,2,31,19" Id="MUV0qLKDcExO6Afx88BP9N">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="&lt;=" />
+                  </p:NodeReference>
+                  <Pin Id="SVnKISeDInoQKM2gmodVdE" Name="Input" Kind="InputPin" />
+                  <Pin Id="FXJeTatbaq8M6Ksz95Nonm" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="ILQdnZ67z4IQBpfVRwdVp7" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="272,1,31,19" Id="VelRAA2DbhQLMrRuJfzrYF">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="&lt;=" />
+                  </p:NodeReference>
+                  <Pin Id="B54ifXlmTEGQMLNC3GsIDi" Name="Input" Kind="InputPin" />
+                  <Pin Id="Rs5hfOJ9V89P4Je9ji4s3N" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="CWMzOV4bXL9NZRVTlPMDne" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="Qxvu5h0z7v3QT1yEtY2cZ6" Bounds="205,-15,35,15" ShowValueBox="true" isIOBox="true" Value="224">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="Tew9Bi8xHB9Qbne09BXUpm" Bounds="300,-13,35,15" ShowValueBox="true" isIOBox="true" Value="239">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Integer32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="234,33,43,19" Id="AmozmPGHg3zNUeKfiJSjL8">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="AND" />
+                  </p:NodeReference>
+                  <Pin Id="E3Dx6S3dz6gP4ruiqMMygT" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="GJPVH3NtCKFPh6tqixHuqh" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="C2OR3i0ZA09P4KKBX6eTyC" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="317,61,77,19" Id="HvFAniANGlpNZq5cML5Uiq">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SwitchOutput" />
+                  </p:NodeReference>
+                  <Pin Id="JL7c2AGaqGiMSBPfJ72zvD" Name="Condition" Kind="InputPin" />
+                  <Pin Id="JHqbUzxGsXNNAHDu4sk4HL" Name="Input" Kind="InputPin" />
+                  <Pin Id="ILoQd4g4IGxMZJbsemSZll" Name="Default" Kind="InputPin" DefaultValue="0.0.0.0" />
+                  <Pin Id="RuDm93rPkNAOLblVLOwmQx" Name="True" Kind="OutputPin" />
+                  <Pin Id="Mj73JmmQokTQaC7V1tfqnJ" Name="False" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="191,-74,80,19" Id="M4YzXpaNtNQOd3HhnsKZrE">
+                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
+                  </p:NodeReference>
+                  <Pin Id="GbXTt4A20OFMTQNHouwABU" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="ESoAqflca9NQOyICatqU3d" Name="Default Value" Kind="InputPin" DefaultValue="0" />
+                  <Pin Id="TSYf5lj5RGHLCYM3UnvnzT" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="AhIcEE3qVBYMcBIDOe0xmf" Name="Result" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="Smur77uCCOnLkypORsL79k" Bounds="355,-123" Alignment="Top" />
+              <ControlPoint Id="GpJqen0ntMEPNYjGQA4zXf" Bounds="387,101" Alignment="Bottom" />
+              <ControlPoint Id="ETxFkIyTzvOOSyXtB2U8jl" Bounds="347,101" Alignment="Bottom" />
             </Node>
           </Canvas>
           <ProcessDefinition Id="IZO13dCXPUzQKfkMuhxPZn">
@@ -1506,42 +1525,29 @@
           <Link Id="RveScHlHYfwOqbYlOJHENj" Ids="McD0rxChkpRLOYuk7MplTj,NwQzLfrV2AGOAePvv75MPU" />
           <Link Id="G3X0lw997A6PG2xMaNu1jD" Ids="Ewzj4L0E9U6OYAXMS2ezDh,H2WWG9ZHfv3LMqW23agL6i" />
           <Link Id="IjRcGGZXYqgLP8Ol0URBTW" Ids="BW1aqDkFEILONSETbCIoaF,Ewzj4L0E9U6OYAXMS2ezDh" IsHidden="true" />
-          <Link Id="DLYnh3FFgPaQdmejVD8qws" Ids="D194eFIpaTxLntHnVFzUNp,RZ6nTtNAwQ8On0V7ZcenOJ" />
-          <Link Id="HdfEoO1VnTxPxyZelLUZN6" Ids="J8aZnWHx591NZ4zbZ6CLNv,TOeIUe7AQMoLhbCOBe7uqv" />
-          <Link Id="LSdGVBtnIi2OEjiTw0U3lh" Ids="SawQaa3S6qbLeCMoyza30H,F3qOUBvEhZFMYJWjfJjoVA" />
-          <Link Id="LG8rrZGYZRGMWZL28XIaMD" Ids="N2lQ5bKtEZOPMds4nF3kaI,FXJeTatbaq8M6Ksz95Nonm" />
-          <Link Id="IMjiTUKvBw7N49EDxQGP43" Ids="N2lQ5bKtEZOPMds4nF3kaI,B54ifXlmTEGQMLNC3GsIDi" />
-          <Link Id="BG4FAvMgzVAQVIFynQ0JnL" Ids="Qxvu5h0z7v3QT1yEtY2cZ6,SVnKISeDInoQKM2gmodVdE" />
-          <Link Id="AHpTaBgCQA6MuDqYqCbYpE" Ids="Tew9Bi8xHB9Qbne09BXUpm,Rs5hfOJ9V89P4Je9ji4s3N" />
-          <Link Id="CXZqqmbNNlTMrNe8WusDWC" Ids="ILQdnZ67z4IQBpfVRwdVp7,E3Dx6S3dz6gP4ruiqMMygT" />
-          <Link Id="Etdhn6A1vAzMtYn4vMC1D7" Ids="CWMzOV4bXL9NZRVTlPMDne,GJPVH3NtCKFPh6tqixHuqh" />
-          <Link Id="MhjPux5niCPLqoi0upsY6F" Ids="C2OR3i0ZA09P4KKBX6eTyC,JL7c2AGaqGiMSBPfJ72zvD" />
-          <Link Id="UGFsAPKpqyKOEhS4p4wWgR" Ids="D194eFIpaTxLntHnVFzUNp,JHqbUzxGsXNNAHDu4sk4HL" />
-          <Link Id="QzOquqDUI3COElhsUr3JVu" Ids="Mj73JmmQokTQaC7V1tfqnJ,V3Yg9CQUjy9NoEuG1UMW8f" />
-          <Link Id="F09RgCfA6htOVErHKcf4ct" Ids="RuDm93rPkNAOLblVLOwmQx,BZ6bOI7mpM8LUwN7AVMUsZ" />
           <Patch Id="TuOkxV9syBxPwRTvVZB6JZ" Name="Create" />
           <Patch Id="NPwec6eTeoYO8uqHWVKkZr" Name="Update" ManuallySortedPins="true">
             <Pin Id="KFcV8Y1t85lMBfH2z1jXIF" Name="Listening IP" Kind="InputPin" Bounds="546,285" />
             <Pin Id="OfPiFZFtU1bQGlGqp3AQzo" Name="Port" Kind="InputPin" Bounds="669,279" DefaultValue="4444">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="HWExlgqRXt1MKcqPYDVUCr" Name="Enable Data Preview" Kind="InputPin" Bounds="500,278" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="BW1aqDkFEILONSETbCIoaF" Name="Sort Data Preview" Kind="InputPin" Bounds="703,599" />
             <Pin Id="MFV8Jj2EI1zMJQS5GVv3pQ" Name="Reset Data Preview" Kind="InputPin" Bounds="787,388" DefaultValue="False">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="OJlbgMSVvlgNdJeNIRtcpd" Name="Enabled" Kind="InputPin" Bounds="900,293" />
             <Pin Id="LmJ7kikouupOoTBg8xiYF9" Name="Data" Kind="OutputPin" Bounds="741,310" />
             <Pin Id="PsyNzSRWz6LM2vjdHCA4y5" Name="Data Preview" Kind="OutputPin">
-              <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
                   <TypeReference>
@@ -1558,6 +1564,22 @@
             <Pin Id="Gph0Y88wPqZMJjqgLqAnK6" Name="Is Open" Kind="OutputPin" Bounds="834,381" />
           </Patch>
           <Patch Id="PIIxrGbrZY8LUMnOh6gxfG" Name="Dispose" />
+          <Link Id="LG8rrZGYZRGMWZL28XIaMD" Ids="N2lQ5bKtEZOPMds4nF3kaI,FXJeTatbaq8M6Ksz95Nonm" />
+          <Link Id="IMjiTUKvBw7N49EDxQGP43" Ids="N2lQ5bKtEZOPMds4nF3kaI,B54ifXlmTEGQMLNC3GsIDi" />
+          <Link Id="BG4FAvMgzVAQVIFynQ0JnL" Ids="Qxvu5h0z7v3QT1yEtY2cZ6,SVnKISeDInoQKM2gmodVdE" />
+          <Link Id="AHpTaBgCQA6MuDqYqCbYpE" Ids="Tew9Bi8xHB9Qbne09BXUpm,Rs5hfOJ9V89P4Je9ji4s3N" />
+          <Link Id="CXZqqmbNNlTMrNe8WusDWC" Ids="ILQdnZ67z4IQBpfVRwdVp7,E3Dx6S3dz6gP4ruiqMMygT" />
+          <Link Id="Etdhn6A1vAzMtYn4vMC1D7" Ids="CWMzOV4bXL9NZRVTlPMDne,GJPVH3NtCKFPh6tqixHuqh" />
+          <Link Id="MhjPux5niCPLqoi0upsY6F" Ids="C2OR3i0ZA09P4KKBX6eTyC,JL7c2AGaqGiMSBPfJ72zvD" />
+          <Link Id="LHSmPdFTJZ8PPqXoRdME2t" Ids="J8aZnWHx591NZ4zbZ6CLNv,GbXTt4A20OFMTQNHouwABU" />
+          <Link Id="L8ByLHS8ovkMG9uT7Spy4R" Ids="AhIcEE3qVBYMcBIDOe0xmf,F3qOUBvEhZFMYJWjfJjoVA" />
+          <Link Id="BceMWIIUcWqOCU43K9UlEY" Ids="D194eFIpaTxLntHnVFzUNp,Smur77uCCOnLkypORsL79k" />
+          <Link Id="GMP7DG9iLP4OkR14dGUmxD" Ids="Smur77uCCOnLkypORsL79k,RZ6nTtNAwQ8On0V7ZcenOJ" />
+          <Link Id="Bl0eWW9vVP7P22x6eHNoyN" Ids="Smur77uCCOnLkypORsL79k,JHqbUzxGsXNNAHDu4sk4HL" />
+          <Link Id="FVdKtArcHVLQNss8ycY5rq" Ids="RuDm93rPkNAOLblVLOwmQx,GpJqen0ntMEPNYjGQA4zXf" />
+          <Link Id="Nr9XspIp39IN2uIsglrmqe" Ids="GpJqen0ntMEPNYjGQA4zXf,BZ6bOI7mpM8LUwN7AVMUsZ" />
+          <Link Id="PmtjrQangI3LaknVcn7oZk" Ids="Mj73JmmQokTQaC7V1tfqnJ,ETxFkIyTzvOOSyXtB2U8jl" />
+          <Link Id="ScrQ5RPqpUELxL8RchnmbH" Ids="ETxFkIyTzvOOSyXtB2U8jl,V3Yg9CQUjy9NoEuG1UMW8f" />
         </Patch>
       </Node>
       <Canvas Id="TshVZcgFWPzMtRWbg0h9kk" Name="Internal" Position="669,222">
@@ -1575,7 +1597,7 @@
             <Canvas Id="M4mHctunxQjMbLWyxjnKCq" CanvasType="Group">
               <ControlPoint Id="A60LDbWq3jAOwy0NpiWXle" Bounds="335,185" />
               <Node Bounds="333,220,135,148" Id="I2hXf2pCmCuPldQ9alrf1V">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="ProcessAppFlag" Name="ForEach (Keep)" />
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 </p:NodeReference>
@@ -1593,7 +1615,7 @@
                   <ControlPoint Id="DrlZBy7ekzlMtOH5yhY53v" Bounds="347,359" />
                   <ControlPoint Id="E7ab4Bvm9mGMdK5guLV3Pp" Bounds="414,361" />
                   <Node Bounds="345,254,51,26" Id="TIz6CBpJFW2PTprI5gUjau">
-                    <p:NodeReference LastCategoryFullName="IO.Socket.Datagram" LastSymbolSource="VL.CoreLib.IO.vl">
+                    <p:NodeReference LastCategoryFullName="IO.Socket.Datagram" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Datagram" />
                       <Choice Kind="OperationCallFlag" Name="Payload" />
@@ -1602,7 +1624,7 @@
                     <Pin Id="F7pkHdcWnSiNP4anPVNy05" Name="Payload" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="345,304,50,19" Id="RjPdNdnKc4BLKCaKbPj3Er">
-                    <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                    <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Unpack" />
                     </p:NodeReference>
@@ -1648,7 +1670,7 @@
             </p:NodeReference>
             <Patch Id="HiuQ9pbHHz2O1iODufiGb8" ManuallySortedPins="true">
               <Node Bounds="414,842,51,19" Id="DHVceM570PfPSvGiDcKqcj">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PadNull" />
                 </p:NodeReference>
@@ -1656,7 +1678,7 @@
                 <Pin Id="AsClM0fA5SWLBMcwRpr0HB" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="417,789,83,26" Id="VnYSl11f3vNOOXLtZ23cX9">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="FromSequence" />
                   <FullNameCategoryReference ID="Collections.Spread" />
                 </p:NodeReference>
@@ -1670,7 +1692,7 @@
               <Link Id="JqlNUMHlBMZPCsA6SybDt7" Ids="ENZiWRJpsIDPhRRtLOMjiR,OMlXN73L81PPTehNGl73aU" IsHidden="true" />
               <Link Id="HELs3Tlwc4UPP6D7oWk5Mq" Ids="UBMakVODp3qP2Sa9ocKd73,EE4t9BzyWTbLlAoE67CKwm" IsHidden="true" />
               <Node Bounds="415,751,52,19" Id="MV2poRxo26vM90FOP3PLQ8">
-                <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToBytes" />
                   <CategoryReference Kind="Category" Name="String" />
@@ -1680,7 +1702,7 @@
                 <Pin Id="MvRv5AGEnn1PgZTIRXPyzk" Name="Result" Kind="OutputPin" />
               </Node>
               <Pad Id="Bkgx3zINGVePquC1OpSu67" Bounds="458,709,93,19" ShowValueBox="true" isIOBox="true" Value="ASCII">
-                <p:TypeAnnotation LastCategoryFullName="Text" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Text" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Encodings" />
                   <CategoryReference Kind="Category" Name="Text" />
                 </p:TypeAnnotation>
@@ -1689,7 +1711,7 @@
               <Link Id="Khq0ruljEUpPhwrxpEMxmW" Ids="OMlXN73L81PPTehNGl73aU,FqRmPk7nxHYMiPF0S3zEln" />
               <Link Id="VTCCA82T7toQbyGsoWSk3W" Ids="MvRv5AGEnn1PgZTIRXPyzk,Sn8J0GPGTjFOBKaEOH0Qp7" />
               <Pin Id="ENZiWRJpsIDPhRRtLOMjiR" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
@@ -1707,7 +1729,7 @@
             </p:NodeReference>
             <Patch Id="VEl3g7L2kroOhlcsTSlpDs" ManuallySortedPins="true">
               <Node Bounds="401,165,79,19" Id="Ia7GxgYYjwjMgMQs15sMno">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="GetInt32Bytes" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -1715,14 +1737,14 @@
                 <Pin Id="RJ8SH03yLtRLEbsi4DtW13" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="446,194,77,19" Id="G70ROax8isvO4k1ac0I0Ko">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="IsLittleEndian" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
                 <Pin Id="OmShfGQQ9FhL9p2f4w3Kmd" Name="Is Little Endian" Kind="OutputPin" />
               </Node>
               <Node Bounds="405,239,61,19" Id="CCnI7JS7VQyN4pmZXZt1FO">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -1739,7 +1761,7 @@
               <Link Id="K9KLP0xehYYMKXgTXyS8nW" Ids="JcakQxvSxiGQNeuSEn2dYw,F75BggC1wS5OjHmnX0AaIg" IsHidden="true" />
               <Link Id="McZ9zvp3yVyOR8KumiAheO" Ids="SFRRGQxfR5XMqqblTdeJEr,JzHAuj2DQjhN6pq9hIHIx8" IsHidden="true" />
               <Pin Id="JcakQxvSxiGQNeuSEn2dYw" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -1757,7 +1779,7 @@
             </p:NodeReference>
             <Patch Id="NG98xYiQoDMOvekgMrXUIV" ManuallySortedPins="true">
               <Node Bounds="612,146,90,19" Id="PcXaLuZD8oxNBYuUSv8e0g">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="GetInt64Bytes" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -1765,7 +1787,7 @@
                 <Pin Id="JZNGt4nFmIzMGLM9lTk2Nc" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="619,207,61,19" Id="IIKCZlrZHGvLCoZtKqTzN6">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -1774,7 +1796,7 @@
                 <Pin Id="RV4YZYGpMf7LsNZCFivofR" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="672,177,87,19" Id="Kc3Ii2NJKgTNqBXUQC67ew">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="IsLittleEndian" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -1789,7 +1811,7 @@
               <Link Id="UyDB4OZyYNGN8C7Dhf12kz" Ids="KdfZPFUOUzuLwoJKyu9Ec3,I4JG8bRjHbPOLuf0hAdCZ7" IsHidden="true" />
               <Link Id="NlB590EpsmrQL031X7Sr3f" Ids="AJZDAPOIE1dL2y8dMYLvpg,JRfPu3yvSJJPRcpeK9IqR4" IsHidden="true" />
               <Pin Id="KdfZPFUOUzuLwoJKyu9Ec3" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer64" />
                 </p:TypeAnnotation>
               </Pin>
@@ -1811,7 +1833,7 @@
               <Link Id="TIGzQ0Bz5cmM1bETDjr4Bu" Ids="GiOu3ZvVRdVQPdcPfkD1OB,KhjMRY4lF4EMPG03aEiCL3" IsHidden="true" />
               <Link Id="BkqL5P3hOgAMrq1dP9lbCU" Ids="F6kVE6BkTgEQJqXF4kafk8,FnMyaEhasaLNCKIC81ZLgE" IsHidden="true" />
               <Node Bounds="651,719,55,19" Id="BD1HUOelQGYMMAmiOd3JpK">
-                <p:NodeReference LastCategoryFullName="System.Conversion" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ToString" />
                 </p:NodeReference>
@@ -1820,7 +1842,7 @@
               </Node>
               <Link Id="KLvJnpStgxZPUTKjw7b14Y" Ids="KhjMRY4lF4EMPG03aEiCL3,QZt2AsyNrzONguXbR2SE4L" />
               <Node Bounds="650,761,64,19" Id="ApQXzZrzgz7MprH0Ukm8xT">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackString" />
                 </p:NodeReference>
@@ -1830,7 +1852,7 @@
               <Link Id="DZClbQr5oGMNt9JBy1fn9W" Ids="T4ynOKvZKiCNI0AEDqdlqF,Q97iQaTimcKLp8zQ8B96JA" />
               <Link Id="K3fvYvlJVNoO2XVrgVvloe" Ids="TRl3KfOm3rzQPm9yVPWStk,F6kVE6BkTgEQJqXF4kafk8" />
               <Pin Id="GiOu3ZvVRdVQPdcPfkD1OB" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Char" />
                 </p:TypeAnnotation>
               </Pin>
@@ -1848,7 +1870,7 @@
             </p:NodeReference>
             <Patch Id="Ckh2Uea1uJtLGoKsKJrufK" ManuallySortedPins="true">
               <Node Bounds="412,439,90,19" Id="K4WV8nwiK8HPsOjwTNsLT9">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="GetFloat32Bytes" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -1856,7 +1878,7 @@
                 <Pin Id="KGf4WonropaNz755sa99A7" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="413,506,61,19" Id="IBLfUgQmGUEMcm0hUM3aDo">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -1865,7 +1887,7 @@
                 <Pin Id="IAfD0xWzBZVLhB5x1Bb9tJ" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="488,473,77,19" Id="MwQZvSnjCxGLt94V6DFrnq">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="IsLittleEndian" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -1880,7 +1902,7 @@
               <Link Id="KkU5mmor2IfL5t4WzrHGoo" Ids="GdzQeqES9SAPXlxoaJtWJP,FJxO6MhiXtMMGIkar8CwGE" IsHidden="true" />
               <Link Id="NDQ0963VY2QQQYElZnG3nn" Ids="BIBcNA6RbbAMOBuiObA3zI,UZnOy79l6KtNJM2JF4nv95" IsHidden="true" />
               <Pin Id="GdzQeqES9SAPXlxoaJtWJP" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -1898,7 +1920,7 @@
             </p:NodeReference>
             <Patch Id="TiwRIcuhY6LOgntsYXQuiY" ManuallySortedPins="true">
               <Node Bounds="630,446,90,19" Id="Q6k0H3VdIUFLArFHQb6Y75">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="GetFloat64Bytes" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -1906,14 +1928,14 @@
                 <Pin Id="PWZ5PbLntRYNCO6ftJEzMc" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="682,489,77,19" Id="VkKBc7mKiOmO7goYor54FP">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="IsLittleEndian" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
                 <Pin Id="GsNNIqGpnBbOOH74WfgZqs" Name="Is Little Endian" Kind="OutputPin" />
               </Node>
               <Node Bounds="630,526,61,19" Id="ScV72hM8dMoPqfcUbMwe9c">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -1930,7 +1952,7 @@
               <Link Id="DskzbECy7U7OfCKyUBKrKu" Ids="RQy7mN8nujuNYQ5H2nknF9,PXeTfbyqG3rNqzPRORLuYw" IsHidden="true" />
               <Link Id="C6UdMBNyIjQOmaWaPs0ZRb" Ids="KletaHVy4a6PJkjFAh1Zbj,ORoY7nnAqeILgn3cA9O24A" IsHidden="true" />
               <Pin Id="RQy7mN8nujuNYQ5H2nknF9" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Float64" />
                 </p:TypeAnnotation>
               </Pin>
@@ -1950,13 +1972,13 @@
               <Pin Id="PSG4buRUzANQNkRICd72ij" Name="Input" Kind="InputPin" />
               <Pin Id="MBzUWFU05krNStl8KTjkwe" Name="Output" Kind="OutputPin" />
               <Pad Id="HHvnar7DaPKMhq1HDETe1o" Bounds="144,474,20,15" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="59,603,33,19" Id="MRBMWmz9hHENWR1wPlIwX9">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="&gt;" />
                 </p:NodeReference>
                 <Pin Id="D6k3rLK4fU6NajUyZVjHIo" Name="Input" Kind="InputPin" />
@@ -1964,7 +1986,7 @@
                 <Pin Id="QRcvmkrRqpEQNsnjA2hh0x" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="106,569,25,19" Id="Nyhcar5cAe7MaSm7dKzODT">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="-" />
                 </p:NodeReference>
                 <Pin Id="I5LWH2CfuaULTSs1GjkVFV" Name="Input" Kind="InputPin" />
@@ -1972,7 +1994,7 @@
                 <Pin Id="QhLteu63oWtQOZh5DfKPWn" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="118,517,25,19" Id="NLP5ADYUaxHMCaPiPiLY8X">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="MOD" />
                 </p:NodeReference>
                 <Pin Id="IH3Oxn3RrmgL40LODtknWo" Name="Input" Kind="InputPin" />
@@ -1980,7 +2002,7 @@
                 <Pin Id="IY9xY39b4DUQceYRZddcFH" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="67,474,66,26" Id="KfCyYl0ZVZLL0NCH05v7Ov">
-                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Count" />
                   <FullNameCategoryReference ID="Collections.Builder.SpreadBuilder" />
                 </p:NodeReference>
@@ -1989,7 +2011,7 @@
                 <Pin Id="Qq5OSdTbrafQTcXrzhlGG6" Name="Count" Kind="OutputPin" />
               </Node>
               <Node Bounds="101,431,53,26" Id="Oeb3CGsrOF1LE1tBwGL3Mj">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="ToBuilder" />
                   <CategoryReference Kind="Category" Name="Spread" />
                 </p:NodeReference>
@@ -1997,7 +2019,7 @@
                 <Pin Id="K3Q4EdSSPyBMcJ3OStabYm" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="60,634,191,224" Id="TPqSybOgj0jNPn67xGkHNf">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:NodeReference>
@@ -2006,7 +2028,7 @@
                 <ControlPoint Id="BbF3VOJXGR6NaJvckUPxuL" Bounds="123,852" Name="SpreadBuilder" Alignment="Bottom" />
                 <Patch Id="B14TeeefZDHNYBf8Q90QlB" IsGeneric="true">
                   <Node Bounds="111,670,128,152" Id="NGH1JApV1PqNrRuV10FpZW">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
                       <CategoryReference Kind="Category" Name="Primitive" />
                     </p:NodeReference>
@@ -2016,12 +2038,12 @@
                     <Pin Id="BaLIVmoqqgqQDR6Y2WNDd7" Name="Break" Kind="OutputPin" />
                     <Patch Id="ShwykybTyCpPi75nxBY0y7">
                       <Pad Id="NSMHojWzXUtPXcJGnSo7s5" Comment="Item" Bounds="164,713,20,15" ShowValueBox="true" isIOBox="true" Value="0">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Byte" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="124,755,66,26" Id="ARxBmjprx0bNK8KLAv7F4z">
-                        <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                        <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationNode" Name="Add" />
                           <FullNameCategoryReference ID="Collections.Builder.SpreadBuilder" />
                         </p:NodeReference>
@@ -2075,7 +2097,7 @@
               <Pin Id="ONFPd3dILK7NTUWvnurhKT" Name="Input" Kind="InputPin" />
               <Pin Id="Pl4LNPrKv28NrUnWEtWijU" Name="Output" Kind="OutputPin" />
               <Node Bounds="863,453,46,19" Id="QwfnB8XwW9AM4sTTgeABf0">
-                <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Vector (Split)" />
                   <CategoryReference Kind="Category" Name="Vector2" />
                 </p:NodeReference>
@@ -2084,7 +2106,7 @@
                 <Pin Id="P0WGckcr63kPhbC4pOwtYy" Name="Y" Kind="OutputPin" />
               </Node>
               <Node Bounds="862,500,16,19" Id="JdVPvAuyZyxPEFOyyNioh6">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2092,7 +2114,7 @@
                 <Pin Id="MMp7JDJfLhsMoPHtG4hbx1" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="960,501,16,19" Id="BHu8jpOqKMNLVFL1esYRP6">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2100,7 +2122,7 @@
                 <Pin Id="JhevIgSJ510PyOwr2s0eZI" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="868,548,97,19" Id="OpM0e0PDzO6LbBao34thQ1">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Concat" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -2109,7 +2131,7 @@
                 <Pin Id="MYejsmL835ROVvIy2GJlPe" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="870,596,83,26" Id="MXnwkFjKI9hQMbu202u1B2">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="FromSequence" />
                   <FullNameCategoryReference ID="Collections.Spread" />
                 </p:NodeReference>
@@ -2142,7 +2164,7 @@
               <Pin Id="RCilNRUxfesNqzRgC11Ct4" Name="Input" Kind="InputPin" />
               <Pin Id="VUkN8zANJSNNjKBpyMXS8D" Name="Output" Kind="OutputPin" />
               <Node Bounds="1135,454,46,19" Id="EPnvwWti4s7NTP5YOBiH2o">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Vector (Split)" />
                   <CategoryReference Kind="Category" Name="Vector3" />
                 </p:NodeReference>
@@ -2152,7 +2174,7 @@
                 <Pin Id="Svk7zN1tlZgLNF46dxv5Or" Name="Z" Kind="OutputPin" />
               </Node>
               <Node Bounds="1134,501,16,19" Id="CDSRPwInHPIMed9iOILckz">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2160,7 +2182,7 @@
                 <Pin Id="UWkZjE3doBiNz30vVDly3j" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1232,502,16,19" Id="HIBUN6GfuRCPrJDuqp98ki">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2168,7 +2190,7 @@
                 <Pin Id="EfHStkgHqZMQCPARL9IvgF" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1140,549,191,19" Id="ErYDBOQhKAtMv8UY8AqfjP">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Concat" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -2178,7 +2200,7 @@
                 <Pin Id="TElDXzSSXB8PMiQTs2RPgE" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1140,596,83,26" Id="CyDRUhOkzaVMzxlv25lrKv">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="FromSequence" />
                   <FullNameCategoryReference ID="Collections.Spread" />
                 </p:NodeReference>
@@ -2186,7 +2208,7 @@
                 <Pin Id="VRsKSarwaWeLR4OhQhkbAz" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="1328,503,16,19" Id="DdSFX1AmPCgMGRjcy63SIk">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2221,7 +2243,7 @@
               <Pin Id="NmxwzhMkt7FLrY8BhOHa1p" Name="Input" Kind="InputPin" />
               <Pin Id="GxMSbzWiGvZMry1CRUXw4Z" Name="Output" Kind="OutputPin" />
               <Node Bounds="1481,422,65,19" Id="TMBT90I7DNuLAbvW0iTEth">
-                <p:NodeReference LastCategoryFullName="3D.Vector4" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector4" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Vector (Split)" />
                   <CategoryReference Kind="Category" Name="Vector4" />
                 </p:NodeReference>
@@ -2232,7 +2254,7 @@
                 <Pin Id="FEQ5rtLxu9DPILY1MwU0zd" Name="W" Kind="OutputPin" />
               </Node>
               <Node Bounds="1480,469,16,19" Id="F5ZmZJWzrwMNJXVAg56bKi">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2240,7 +2262,7 @@
                 <Pin Id="C8Bz7WmNbOGQR2so6Mo4dj" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1578,470,16,19" Id="BVY5oLw1Pz2N3WMhZNYx9L">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2248,7 +2270,7 @@
                 <Pin Id="L6VvU36VRvKL9v6Ef0d2Lk" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1486,517,289,19" Id="RkiYmi8vU7oO94y5fSmkhK">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Concat" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -2259,7 +2281,7 @@
                 <Pin Id="ROGwn5T6GhuLkBIxofGS05" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1486,564,83,26" Id="DTtVMg2yFs3LEpyxsGuVb8">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="FromSequence" />
                   <FullNameCategoryReference ID="Collections.Spread" />
                 </p:NodeReference>
@@ -2267,7 +2289,7 @@
                 <Pin Id="BR1SyaoLtNDNFROm0j7AcX" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="1769,470,16,19" Id="Ir6LA0x6bv8LzGKQ0VRbqg">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2275,7 +2297,7 @@
                 <Pin Id="Icbiqxe9L9CPES7bWV6G4B" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1671,469,16,19" Id="NUFfnldLsGMPtdlFZg1SgW">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackFloat32" />
                 </p:NodeReference>
@@ -2316,7 +2338,7 @@
               <Link Id="JTr1pLcBY9KNRrQRsZouSp" Ids="Hajz80I1K7APjGgZFU9SLo,KMTTh6k6UxkMLUbaFpLaYR" IsHidden="true" />
               <Link Id="GGzRrkIRF7vPT5mQyIVouS" Ids="IOM5xUuDhbrNYKL3mzwFNt,D1n31GhvcqOP1ImmyGGKY4" IsHidden="true" />
               <Node Bounds="425,1013,60,26" Id="SQMbC8c3SavPfWOAPvkij3">
-                <p:NodeReference LastCategoryFullName="Color.RGBA" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ToInteger" />
                 </p:NodeReference>
@@ -2325,7 +2347,7 @@
               </Node>
               <Link Id="BSMpOCBFX2wO99WXeaFMjc" Ids="KMTTh6k6UxkMLUbaFpLaYR,Pz2jG04lG7VPLGgst3Hsup" />
               <Node Bounds="425,1066,81,19" Id="VcVFhAZoLAPQLefyJZkmjA">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackInteger32" />
                 </p:NodeReference>
@@ -2351,7 +2373,7 @@
               <Link Id="P484BfOrobvLnQ1qKfnF6t" Ids="OjvimjMN7YZM6zFAWv2MeQ,GIaQ42JL0UlPESULqb80af" IsHidden="true" />
               <Link Id="SBAGTNFeGbtMXhwHTRlM0d" Ids="HoQoorm1997MnRjAcbJKUw,LH3JHJGRRIZQWHXFv6ehCE" IsHidden="true" />
               <Node Bounds="428,1407,51,19" Id="JKXE6R3ddtNQaua5lLx2eV">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PadNull" />
                 </p:NodeReference>
@@ -2359,7 +2381,7 @@
                 <Pin Id="MkAKcbOf8LfO8XUCcbA7Tp" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="428,1254,44,19" Id="DSjCFTQ8acXOnbCD0oQ3qH">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Count" />
                   <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -2369,7 +2391,7 @@
               </Node>
               <Link Id="QRswbigzw8aOoCyp64Hd8b" Ids="GIaQ42JL0UlPESULqb80af,PdKYmaIvmvEOmhCF5vWkva" />
               <Node Bounds="428,1331,48,19" Id="N1kk5kFSnROO8GiJS1UHdg">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Concat" />
                   <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -2380,7 +2402,7 @@
               </Node>
               <Link Id="T47ZizTvnJpNMNjRIVDeCf" Ids="GIaQ42JL0UlPESULqb80af,BQWafnd4pfvMuhDp6CuofJ" />
               <Node Bounds="428,1365,83,26" Id="QLCGoeGhklwOl1sEdh1JUc">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="FromSequence" />
                   <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -2392,7 +2414,7 @@
               <Link Id="DSu55ewcunCMETwQidY3VG" Ids="MY8imCJnA4aLk5yYEbeVSK,MMImm7J7XtsMG2GU5FJDxT" />
               <Link Id="SoMF7VFNeqgMpuyyeoE6yb" Ids="MkAKcbOf8LfO8XUCcbA7Tp,HoQoorm1997MnRjAcbJKUw" />
               <Node Bounds="428,1289,81,19" Id="FHxjm6yx2lhMxQ5OZN4jZL">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackInteger32" />
                 </p:NodeReference>
@@ -2402,7 +2424,7 @@
               <Link Id="JeeipFBbImWLH1iB1lcfx4" Ids="F5BB3ShY0uEMYY5iZm1XHO,JKzfJ4NYzbiNbIiKITYcey" />
               <Link Id="QzQw2AGsuMhPWCwWJVtOV8" Ids="CxmSdR31aMVLfOc2WxRta2,AlBFzDtubfSNh6l09MtWzH" />
               <Pin Id="OjvimjMN7YZM6zFAWv2MeQ" Name="Input" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Sequence" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -2431,29 +2453,29 @@
               <Pin Id="E4G8FEY0UihNUrgjCRo1V3" Name="Value" Kind="OutputPin" />
               <Pin Id="UL0Tmyn5vdgMfAGKKtbasb" Name="Next Index" Kind="OutputPin" />
               <Pad Id="SXrFjAIaOM6Ox3gLCpnxTr" Bounds="1803,1193,40,19" ShowValueBox="true" isIOBox="true" Value="8">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="I7F8WvPi4xMM7lRjpkUKic" Comment="Month" Bounds="1410,1177,40,19" ShowValueBox="true" isIOBox="true" Value="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="Hl2MjPtD206Nt68UOpX1Vq" Comment="Year" Bounds="1358,1155,36,19" ShowValueBox="true" isIOBox="true" Value="1900">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="H1LDf6QwwpYOmRN92ie6k6" Comment="Count" Bounds="1691,1173,20,19" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="1787,1230,45,19" Id="AOF7K46nyMqOOnjW4ow1Qq">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="+" />
                 </p:NodeReference>
                 <Pin Id="MZEDSJIeSvrMm4pmExR3jo" Name="Input" Kind="InputPin" />
@@ -2462,7 +2484,7 @@
                 <Pin Id="Ach3p4fRm35OFnDItbYOIJ" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1485,1340,72,26" Id="QF5wW9h25uEOy9j5cHvnb7">
-                <p:NodeReference LastCategoryFullName="System.DateTime" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.DateTime" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="Category" Name="DateTime" />
                   <Choice Kind="OperationCallFlag" Name="AddSeconds" />
@@ -2472,7 +2494,7 @@
                 <Pin Id="DEgpAQtrT1pMKd6wvgbfkn" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1486,1389,62,26" Id="V51fdyOL4JuLxXLNHvAvfD">
-                <p:NodeReference LastCategoryFullName="IO.OSC.OSCTimeTag" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.OSCTimeTag" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="Create" />
                   <CategoryReference Kind="Category" Name="OSCTimeTag" />
@@ -2481,7 +2503,7 @@
                 <Pin Id="KQkhkrzujs4O4HIdpVttT0" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1385,1226,51,26" Id="M3sfIV7Hq7BQSYrRg9ihbp">
-                <p:NodeReference LastCategoryFullName="System.DateTime" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.DateTime" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Create (Year Month Day)" />
                   <CategoryReference Kind="Category" Name="DateTime" />
                 </p:NodeReference>
@@ -2506,7 +2528,7 @@
               <Link Id="AGlYCpRyeUSOu5L3ZcRRcV" Ids="LKnG68frrlSO0IrVzvm0Br,E4G8FEY0UihNUrgjCRo1V3" IsHidden="true" />
               <Link Id="KtiMJYh66QDLkGP2efMXVt" Ids="PWf6nFyduyeO08ySZJ6mMA,UL0Tmyn5vdgMfAGKKtbasb" IsHidden="true" />
               <Node Bounds="1506,1228,68,19" Id="J2dq7ljUGCBNFcdFns8IRh">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToUInt32" />
                   <CategoryReference Kind="Category" Name="Spread" />
@@ -2519,7 +2541,7 @@
               <Link Id="HG3gVg0Ev2UMULWZp9aqH9" Ids="E1K5fcsZhtgNuiTPwBCKSr,VQ3Ugg1KeHXLRlqQeeROyQ" />
               <Link Id="SsbBvX8RBboMG1lCd77dAW" Ids="Kvg8vtCVlpsNkFyG2L0Sd3,MActhtP0pE7MXKl0PpYOdq" />
               <Node Bounds="1587,1227,68,19" Id="V1eqiyDqCM3N6NvLLPI4kC">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToUInt32" />
                   <CategoryReference Kind="Category" Name="Spread" />
@@ -2531,14 +2553,14 @@
               </Node>
               <Link Id="PS91V79mIVOLVg8aDe3x9x" Ids="E1K5fcsZhtgNuiTPwBCKSr,IZ8oFu5KykELZ17kPW8jJV" />
               <Pad Id="EI0bTxNTJT1MsjCIz7uvrE" Comment="Input Is Big Endian" Bounds="1573,1113,40,19" ShowValueBox="true" isIOBox="true" Value="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
               </Pad>
               <Link Id="Qtm1ujP06eyNjlcCLkqCxK" Ids="EI0bTxNTJT1MsjCIz7uvrE,Qyp5NO1DeGfOTZanNMgUGb" />
               <Link Id="KzWAatn8Tz3LYFmDPiEjwj" Ids="EI0bTxNTJT1MsjCIz7uvrE,HHU67q309McM0zzhs9DMGN" />
               <Node Bounds="1660,1188,25,19" Id="FvZf3xBsHJzK9ebdDxA3PE">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="+" />
                 </p:NodeReference>
@@ -2550,25 +2572,25 @@
               <Link Id="LU93Z0HyUPvQZ4SZpiujXF" Ids="Kvg8vtCVlpsNkFyG2L0Sd3,JsrKtIcOwUnNsRmACHO7sj" />
               <Link Id="DBtvt7iGEUKL5mv9CuKaq0" Ids="GRRXOSFhua3NatPsCpARus,HgWu81r6bK0QVr4tupljGm" />
               <Node Bounds="1587,1273,25,19" Id="BU3hg3Ks2z8QHz6Ydp0AX6">
-                <p:NodeReference LastCategoryFullName="Primitive.Float64" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Float64" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="/" />
                   <CategoryReference Kind="Float64Type" Name="Float64" NeedsToBeDirectParent="true" />
                 </p:NodeReference>
                 <Pin Id="QmE4ZMNs4qNPNMbCcmTSLO" Name="Input" Kind="InputPin" DefaultValue="1">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float64" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="JPct5b7G2W4MxRmQNYUPe0" Name="Input 2" Kind="InputPin" DefaultValue="4294967296">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float64" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="QgjmTLe6GHGMSOBTXQr5dt" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1526,1293,25,19" Id="BlWaa0GavMOO61p3KEVwxm">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -2583,7 +2605,7 @@
               <Link Id="MbLg5dkgrTbNO8AIIIu3VT" Ids="QgjmTLe6GHGMSOBTXQr5dt,KPU0TsuNuPzPXIqYpEJbrd" />
               <Link Id="VwaZv5Vjb3sM724Zokpymp" Ids="UhhNpoogh79ONkmMx9oY0O,FpUb8mUjbcyLCjmh20iLta" />
               <Pad Id="ShMHGghkJ2lNq2HFkb0OtF" Bounds="1611,1278,103,23" ShowValueBox="true" isIOBox="true" Value="divide by 2^32">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
                 <p:ValueBoxSettings>
@@ -2608,13 +2630,13 @@
               <Pin Id="RKzBySXMjpFMMSs8td1yVg" Name="Value" Kind="OutputPin" />
               <Pin Id="JSLoIgiZ9YnPClXriSX0qC" Name="Next Index" Kind="OutputPin" />
               <Pad Id="NOK9Cbx7t4pONe6FIjm5su" Bounds="1474,-63,40,19" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="1452,-32,-29,19" Id="SawY6oFghpNOkU7AqylXFy">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="+" />
                 </p:NodeReference>
                 <Pin Id="R5iFEoFF3XrMHmgPgWdTVr" Name="Input" Kind="InputPin" />
@@ -2633,7 +2655,7 @@
               <Link Id="MqJ8yi2OMMBLq9Ui55vp1X" Ids="QdV0auESMK4MyBpFtea4do,RKzBySXMjpFMMSs8td1yVg" IsHidden="true" />
               <Link Id="SnTb3WivsisPI5P7URCc5Q" Ids="QVdb2eF7z0mLrKnqpIK2rv,JSLoIgiZ9YnPClXriSX0qC" IsHidden="true" />
               <Node Bounds="1312,-35,62,19" Id="Ko7lPUQqmqXLrTbiObWOQc">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToInt32" />
                   <CategoryReference Kind="Category" Name="Spread" />
@@ -2647,7 +2669,7 @@
               <Link Id="CMisqvioZFtOjDXssZBuks" Ids="AzTvPV988PqP1edQ9Zxcb8,BFewmIGQForQJhb7wb67wW" />
               <Link Id="EoRDAJdMtsaLmjJ4r8DjCU" Ids="GAEXFjIIplJOwI54XGXj1U,QdV0auESMK4MyBpFtea4do" />
               <Pad Id="ME1V9GqRlGlOdaMaxal951" Comment="Input Is Big Endian" Bounds="1328,-71,40,19" ShowValueBox="true" isIOBox="true" Value="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
@@ -2670,13 +2692,13 @@
               <Pin Id="R9oc4duNpX6N7VSjdclpDB" Name="Value" Kind="OutputPin" />
               <Pin Id="GtmPjwWhUWONeNGmjKUJ0N" Name="Next Index" Kind="OutputPin" />
               <Pad Id="UVh4rzUf2gANrjQ0LPy3vo" Bounds="1809,-83,40,19" ShowValueBox="true" isIOBox="true" Value="8">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="1789,-37,-130,19" Id="PsGYJLyvUiyNcZC7ge4lMN">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="+" />
                 </p:NodeReference>
                 <Pin Id="MUs18tAKRB4LwAGj4tz5CD" Name="Input" Kind="InputPin" />
@@ -2695,7 +2717,7 @@
               <Link Id="JMqCnorXipXOw2I9YM59Ij" Ids="JpnQ5qdKaaWMXJd9sZTE8D,R9oc4duNpX6N7VSjdclpDB" IsHidden="true" />
               <Link Id="BFVnpGYihJkLXFFKAX5jYM" Ids="ORjYZ2lu6MWNtnVlhPof7H,GtmPjwWhUWONeNGmjKUJ0N" IsHidden="true" />
               <Node Bounds="1635,-32,62,19" Id="ClB1CKJe6pLL7Sx2CuJzLo">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToInt64" />
                   <CategoryReference Kind="Category" Name="Spread" />
@@ -2709,7 +2731,7 @@
               <Link Id="VQPL81xQmJYMvvybtvg1YX" Ids="LQzrLUywdGAPbjNnJMVzte,HTt0IzTd4WoNKLzceKistp" />
               <Link Id="Pwg8kvaB8K1NKsvzxd4c7v" Ids="OmmSPlk1MJ4Odtgk3rncX5,JpnQ5qdKaaWMXJd9sZTE8D" />
               <Pad Id="Sf2BPPDZWI7NVyUWSsnbRo" Comment="Input Is Big Endian" Bounds="1650,-84,40,19" ShowValueBox="true" isIOBox="true" Value="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
@@ -2732,13 +2754,13 @@
               <Pin Id="MfUoPKGxyhqOs8POSzIstT" Name="Value" Kind="OutputPin" />
               <Pin Id="S1pTj7ii4i3P0RVwv0lPcH" Name="Next Index" Kind="OutputPin" />
               <Pad Id="Q6wTlV2eFffPE2qOJjEaHj" Bounds="1500,193,40,19" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="1479,223,-7,19" Id="ONpwGhLXIgJN5n4yV03i3K">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="+" />
                 </p:NodeReference>
                 <Pin Id="ONGsRemej5CLgdwgGKExto" Name="Input" Kind="InputPin" />
@@ -2757,7 +2779,7 @@
               <Link Id="QxhYT2fGXNDN0MvhtEBEwB" Ids="Gp74vhpKrTcLj4kHhX7x3R,MfUoPKGxyhqOs8POSzIstT" IsHidden="true" />
               <Link Id="H95UpYvgAIhQMtHoC2FNOa" Ids="PjOgYsNXL74NCmTqFNKmVM,S1pTj7ii4i3P0RVwv0lPcH" IsHidden="true" />
               <Node Bounds="1324,209,72,19" Id="R50x3PZ89BFQdVUPZKyOCU">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.DevLib.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToFloat32" />
                   <CategoryReference Kind="Category" Name="Spread" />
@@ -2771,7 +2793,7 @@
               <Link Id="N2um5Iu3XnRMmHL89JCeSi" Ids="CNHck1cA2JpLFFRR1YVz6X,Bg4j2WhCUXiQPcf8n6lf3J" />
               <Link Id="LYgNPZlSTVHQVdTZ9d0rea" Ids="Fav4OHUGjMjNqY2c52peeI,Gp74vhpKrTcLj4kHhX7x3R" />
               <Pad Id="QbDtusu3ht5PS9ghh8kRCD" Comment="Input Is Big Endian" Bounds="1340,172,40,19" ShowValueBox="true" isIOBox="true" Value="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
@@ -2794,13 +2816,13 @@
               <Pin Id="NdMNAvWmBnCL1PJ71xEUDY" Name="Value" Kind="OutputPin" />
               <Pin Id="SmRbQZjEwEfOTXcUyFWMtT" Name="Next Index" Kind="OutputPin" />
               <Pad Id="KrREcJdGQCSLPOr97kRgk1" Comment="Count" Bounds="1838,191,20,19" ShowValueBox="true" isIOBox="true" Value="8">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="1812,227,-74,19" Id="Of25vuXPoqAQGyN8KkwgdP">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="+" />
                 </p:NodeReference>
                 <Pin Id="CELHzHNgnORPBbzXtrsDaD" Name="Input" Kind="InputPin" />
@@ -2819,7 +2841,7 @@
               <Link Id="GnuQ7pYzF4YQSUCckiNTYs" Ids="SUF9ICMvp2FOXRlFCkaSMb,NdMNAvWmBnCL1PJ71xEUDY" IsHidden="true" />
               <Link Id="HhwEWcqb74FNglqsAWHGwU" Ids="P9UgMLpWjFINFb0legZBWB,SmRbQZjEwEfOTXcUyFWMtT" IsHidden="true" />
               <Node Bounds="1660,203,72,19" Id="PiCGVvgpHhWLX2fgQv37uh">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="ToFloat64" />
                   <CategoryReference Kind="Category" Name="Spread" />
@@ -2833,7 +2855,7 @@
               <Link Id="M09hUNlHcHsN35gbzlB1n1" Ids="GLgRjIuknbbNAPrWJBCItu,SUF9ICMvp2FOXRlFCkaSMb" />
               <Link Id="BeNJth8ZdNdPM1Vnkwy9BR" Ids="BfMj05Fk1s5NPWBUgGRqYS,BiynuR5lZfaLxNW89tedmL" />
               <Pad Id="K86LQGuABnuMTnn1K87GIA" Comment="Input Is Big Endian" Bounds="1675,182,40,19" ShowValueBox="true" isIOBox="true" Value="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
@@ -2855,13 +2877,13 @@
               <Pin Id="EEoVEJbSzQYMGj6Gbuqxwm" Name="OSCMessages" Kind="OutputPin" />
               <Pin Id="RLSYwri5dHnP8H9qBRpaMQ" Name="Success" Kind="OutputPin" />
               <Pad Id="Hfp31TEowExNpJflIQzjGw" Bounds="1020,235,-1,-4" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="977,193,37,22" Id="Es7r2roGr4dOi37F3OQ2SK">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Count" />
                   <CategoryReference Kind="Category" Name="Spread" />
                 </p:NodeReference>
@@ -2869,7 +2891,7 @@
                 <Pin Id="M9T9z3F0t8CLGSRV3RLXEp" Name="Count" Kind="OutputPin" />
               </Node>
               <Node Bounds="1008,271,32,13" Id="QA3S16KrkzTNqngcPF53ME">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="MOD" />
                 </p:NodeReference>
                 <Pin Id="Vp0BIqlAyDuOoIuHnWag2f" Name="Input" Kind="InputPin" />
@@ -2877,7 +2899,7 @@
                 <Pin Id="L0lyPgoHLU0NYjxEm0iUB4" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1008,298,25,13" Id="L7E4Uc67PseNSwyc5tBqwb">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="=" />
                 </p:NodeReference>
                 <Pin Id="GasAZjXPblMNoRyW0vmsND" Name="Input" Kind="InputPin" />
@@ -2885,7 +2907,7 @@
                 <Pin Id="AlFm6mEGArQLxVlwPxGZ9l" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="979,340,30,13" Id="BmjoLI693csM9EklnDBGYM">
-                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="AND" />
                   <CategoryReference Kind="Category" Name="Boolean" />
                 </p:NodeReference>
@@ -2894,7 +2916,7 @@
                 <Pin Id="DLFJefOjKhzPWiiJTj2ee0" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="978,300,25,13" Id="Vx7BkWHk5WFLZh5SJOHDu2">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="!=" />
                 </p:NodeReference>
                 <Pin Id="I6LbsRIwZ3qOfTety5MvnN" Name="Input" Kind="InputPin" />
@@ -2902,7 +2924,7 @@
                 <Pin Id="SCfqZzsc0sIOlhaUMWKXtV" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="281,376,637,783" Id="GFSByqaMjTeNjoMxBh2lq8">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="ApplicationStatefulRegion" Name="If" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:NodeReference>
@@ -2911,13 +2933,13 @@
                 <ControlPoint Id="C37wQxmlIlTNp4kmocKJRF" Bounds="841,1154" Name="Messages" Alignment="Bottom" />
                 <Patch Id="NvLJzQH6IRiMnRCd0CRem0" IsGeneric="true">
                   <Pad Id="NaPFLDbfuEBM5R3OrezRmv" Comment="forever" Bounds="330,431,39,-5" ShowValueBox="true" isIOBox="true" Value="9999">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Integer32" />
                       <CategoryReference Kind="Category" Name="Primitive" />
                     </p:TypeAnnotation>
                   </Pad>
                   <Node Bounds="793,1093,66,26" Id="HwY7L5cxSXZOJSLljWOkPX">
-                    <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                    <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="OperationNode" Name="ToSpread" />
                       <FullNameCategoryReference ID="Collections.Builder.SpreadBuilder" />
                     </p:NodeReference>
@@ -2926,7 +2948,7 @@
                     <Pin Id="OqMNq2RwJWALkSVjqZMypm" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="328,476,578,592" Id="Ac98v3QSdrXObR2Ls8XtNR">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
                       <CategoryReference Kind="Category" Name="Primitive" />
                     </p:NodeReference>
@@ -2944,19 +2966,19 @@
                     <ControlPoint Id="SfpJVEHlBfzNJEVQ1CvZPI" Bounds="647,483" Name="Index" Alignment="Top" />
                     <Patch Id="QOa8w0Jk0raM9aZummCx3B">
                       <Pad Id="ATcCEiVJOuoOHB8bybXZjg" Bounds="571,531,48,15" ShowValueBox="true" isIOBox="true" Value="#bundle">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Pad Id="J2KwXX5SFV2PD6cQepHk1h" Bounds="465,662,25,7" ShowValueBox="true" isIOBox="true" Value="0">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:TypeAnnotation>
                       </Pad>
                       <Node Bounds="477,521,77,19" Id="RgrAJkyyd77OaJLcCLGNKX">
-                        <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastSymbolSource="VL.IO.OSC.dll">
+                        <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastDependency="VL.IO.OSC.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationNode" Name="UnpackString" />
                         </p:NodeReference>
@@ -2966,7 +2988,7 @@
                         <Pin Id="EpwRD4I48R8OX3ehDwpKs8" Name="Next Index" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="477,556,25,13" Id="Vx4MLaeZQWYMWFP70RIYef">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationNode" Name="=" />
                         </p:NodeReference>
                         <Pin Id="MRl4HNadlgYNRYmiDmqWnV" Name="Input" Kind="InputPin" />
@@ -2974,7 +2996,7 @@
                         <Pin Id="ENqsQ6RUcjzMGUu4m5Rxbw" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="538,844,100,13" Id="J8XMU5swN1lLRVHycbohLi">
-                        <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                        <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="UnpackMessage" />
                         </p:NodeReference>
@@ -2985,7 +3007,7 @@
                         <Pin Id="AmGPuHR2ZFmL9hL1oaAqIz" Name="Start" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="794,1010,58,22" Id="GkBpadPuo9ANZrOGQwVirK">
-                        <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                        <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationNode" Name="Add" />
                           <FullNameCategoryReference ID="Collections.Builder.SpreadBuilder" />
                         </p:NodeReference>
@@ -2995,7 +3017,7 @@
                         <Pin Id="AONOCPWoLNzNsZ8Z8eGnxs" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="572,984,31,19" Id="Cg8xqEYgon2OQibYr47x3S">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationNode" Name="&gt;=" />
                         </p:NodeReference>
                         <Pin Id="ANIhi3h0t59NN9sZrlEHZr" Name="Input" Kind="InputPin" />
@@ -3003,7 +3025,7 @@
                         <Pin Id="HZHNe43eFwaNvyKH84m0Yq" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="398,623,51,26" Id="LZ1LWkIO7DVOwBdkCHhiwC">
-                        <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationNode" Name="Inc" />
                           <CategoryReference Kind="Category" Name="Integer32" />
@@ -3013,7 +3035,7 @@
                         <Pin Id="KSprfwSVF3rLxXxUpE4e0B" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="452,700,25,13" Id="PLE2qIFVme8PBkZxML7IIF">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationNode" Name="&gt;" />
                         </p:NodeReference>
                         <Pin Id="Ij6u964oiB7M4ENewh0ZvH" Name="Input" Kind="InputPin" />
@@ -3021,7 +3043,7 @@
                         <Pin Id="P0BY56oODZfNsxVG1q9yHO" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="596,606,128,82" Id="H5oferttkC7LF2XwUcfqIx">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
@@ -3032,7 +3054,7 @@
                         <ControlPoint Id="E15QIQxzbSIMMQ8TLyr7Gy" Bounds="707,682" Alignment="Bottom" />
                         <Patch Id="Rd0u6OKCNXwLuRI0bbleYp" IsGeneric="true">
                           <Node Bounds="608,641,54,19" Id="Qi5W0gpgOvgMadd9fTfWU3">
-                            <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                            <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                               <Choice Kind="OperationNode" Name="UnpackTimetag" />
                               <CategoryReference Kind="Category" Name="OSC" />
                             </p:NodeReference>
@@ -3046,7 +3068,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="591,740,134,73" Id="TIh3zInqdm9PcO8mXEAx9K">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
@@ -3057,7 +3079,7 @@
                         <ControlPoint Id="VAG9ZPad3gPMrLtaxLpKEt" Bounds="700,808" Alignment="Bottom" />
                         <Patch Id="Bug0ZWnQmBAPaKreS5DoLK" IsGeneric="true">
                           <Node Bounds="603,773,76,19" Id="BsaGcYUyVA9M71SWb7IVE2">
-                            <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                            <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                               <Choice Kind="OperationNode" Name="UnpackInteger32" />
                               <CategoryReference Kind="Category" Name="OSC" />
                             </p:NodeReference>
@@ -3071,7 +3093,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="700,575,31,19" Id="AJS25jiXOgALaNXssMhTpr">
-                        <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationNode" Name="Switch (Boolean)" />
                           <FullNameCategoryReference ID="Control" />
@@ -3087,7 +3109,7 @@
                       </Patch>
                       <Patch Id="BhCBvCFAbGdPp1tZ9O6lm1" Name="Dispose" />
                       <Pad Id="J4EH5EQaA07L5vNq25vzHM" Bounds="544,916,150,19" ShowValueBox="true" isIOBox="true" Value="settimetag on messag?!">
-                        <p:TypeAnnotation>
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                         <p:ValueBoxSettings>
@@ -3096,7 +3118,7 @@
                         </p:ValueBoxSettings>
                       </Pad>
                       <Node Bounds="780,653,44,26" Id="IbzyR54eKWiMXoFklCWfJH">
-                        <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                        <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Count" />
                           <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -3105,7 +3127,7 @@
                         <Pin Id="Q4tHJKKTiFBPr6QF1IoFAm" Name="Count" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="780,702,25,19" Id="SVgwaOTbhwLOYaAoMMInwl">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="-" />
                         </p:NodeReference>
@@ -3114,7 +3136,7 @@
                         <Pin Id="FvAMQ2ElB1OPxGhg2V6kyS" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Pad Id="VcPRcOnu0f1QQEAy55s8JW" Bounds="722,787,93,19" ShowValueBox="true" isIOBox="true" Value="&lt; bundle size">
-                        <p:TypeAnnotation>
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                         <p:ValueBoxSettings>
@@ -3226,7 +3248,7 @@
               <Link Id="GAclD1BbRRQLgKap34c89K" Ids="UX4FwclrUc0OppqUgM6s4A,DMG4tBsh3SzNnmEbMYFsh1" IsHidden="true" />
               <Link Id="OHJdPPhCtAwPQaRgNMqJqh" Ids="JBiGjhaNEOBNX909qtEpdx,MjKyDxRyDZOPXOlZAP302H" IsHidden="true" />
               <Node Bounds="1338,576,72,26" Id="Oz5g95v9YHLQLZ6hgxpuLm">
-                <p:NodeReference LastCategoryFullName="Color.RGBA" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ColorRGBAType" Name="RGBA" />
                   <Choice Kind="OperationCallFlag" Name="FromInteger" />
@@ -3236,7 +3258,7 @@
               </Node>
               <Link Id="JAmnOIEo1OQLYOsLdPwRPZ" Ids="ANSrY9rvTgrPoTZjiFyrSw,UX4FwclrUc0OppqUgM6s4A" />
               <Node Bounds="1337,537,105,19" Id="SNOK6rexBPsMNh7LnYi7m1">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackInteger32" />
                 </p:NodeReference>
@@ -3270,7 +3292,7 @@
               <Link Id="Fne4ueSpu5uOe4Rfdm8uMd" Ids="DKg1UWX6MPdND1xhuMFzY2,QuMzPgmvXToQeAKfCDhnmM" IsHidden="true" />
               <Link Id="VXwFmwtMTCKLfVgMARZjPF" Ids="I8oKnBlnIB4Nd4qgNhT5YO,U17kn4uk65UPWlsAd0iz8J" IsHidden="true" />
               <Node Bounds="1753,521,66,26" Id="QzFejykOerbPYfR57klxAt">
-                <p:NodeReference LastCategoryFullName="Primitive.Byte" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Byte" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="BitsToChar" />
                   <CategoryReference Kind="ByteType" Name="Byte" NeedsToBeDirectParent="true" />
@@ -3280,7 +3302,7 @@
               </Node>
               <Link Id="FRStbjghp44LzVBixNoUS5" Ids="MM2tb4f1Qi8PsBGI2VjM9t,DKg1UWX6MPdND1xhuMFzY2" />
               <Node Bounds="1754,463,52,26" Id="Gc6cjex5KwxNH1rty8pvrd">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetSlice" />
                   <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -3294,7 +3316,7 @@
               <Link Id="D09nNgMU2rtNYWTZrNPBp4" Ids="IyofXv0jG4fOCvcrLd83SB,OXvkeEZ33neOrYoDupOHXn" />
               <Link Id="ReRnLhHgsEWPEDeeshBQIj" Ids="RusbVltlgUoLUvq1EfseBc,Ikn8bsijVCqLgT0F5ARsvK" />
               <Node Bounds="1854,483,25,19" Id="T8tDDMwtZW3M9ITfPqgW5X">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="+" />
                 </p:NodeReference>
                 <Pin Id="G9MrebFQJPUPPqwBhQl6S8" Name="Input" Kind="InputPin" />
@@ -3304,7 +3326,7 @@
               <Link Id="J6vQJlvVT2HOod7sMDxMox" Ids="IyofXv0jG4fOCvcrLd83SB,G9MrebFQJPUPPqwBhQl6S8" />
               <Link Id="EPLwR5a92jYOvnLeQBRDE9" Ids="TJnpebeH3dYP2lAiNvrsTw,I8oKnBlnIB4Nd4qgNhT5YO" />
               <Pad Id="B5Vyu20Rd3DPgsscGPN3cb" Comment="" Bounds="1881,451,20,19" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
@@ -3312,7 +3334,7 @@
               <Pin Id="NT4UDB75fqRL3q0qd4ttSF" Name="Input" Kind="InputPin" />
               <Pin Id="APVoQeIhVA0OujSy7sdAtk" Name="Start Index" Kind="InputPin" />
               <Pin Id="QuMzPgmvXToQeAKfCDhnmM" Name="Value" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Char" />
                 </p:TypeAnnotation>
               </Pin>
@@ -3336,7 +3358,7 @@
               <Link Id="QTKQXIiuD43LIagNlGsbMa" Ids="FFeD4qv0BLFOepQNo31Qr8,FXY6K3nUDgTQdWBs6UxfE0" IsHidden="true" />
               <Link Id="I4Gm3mjGKyHL6BBFRThzn3" Ids="TFc8IQMSG55PPDfRC4IG1v,UR4rBBwidqROiCNZ5XtWxF" IsHidden="true" />
               <Node Bounds="1357,773,105,19" Id="Q4anLGzQabjMVLmr7504UY">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackInteger32" />
                 </p:NodeReference>
@@ -3348,7 +3370,7 @@
               <Link Id="H2U6uvArGQELBae3ehf8Xn" Ids="AlOB0OKNyOeMMm8YkkeZ96,JzafGYUrvCnP6MpWIG1eap" />
               <Link Id="OlmVuDfLU0kPNIKvqF1Abz" Ids="FXY6K3nUDgTQdWBs6UxfE0,Ct6NpozniABQPmA1F0Xb7I" />
               <Node Bounds="1337,887,63,26" Id="Aio8fMafW5yO3maKkLtEDF">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetSpread" />
                 </p:NodeReference>
@@ -3359,7 +3381,7 @@
               </Node>
               <Link Id="Qb2d7i8LjqhN1zXVDwBh78" Ids="GEDnSt2W6ysPK2dNgl8vn0,RYhoaEddbk9POIxL0CNgTB" />
               <Node Bounds="1436,923,45,19" Id="SauVVob6Cr4MCbwtKHk0nj">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -3370,13 +3392,13 @@
               </Node>
               <Link Id="GsBq5sMhHG5Llg1SllWI8G" Ids="OUOF0klhMkVOIkWBpEYuO5,TFc8IQMSG55PPDfRC4IG1v" />
               <Pad Id="UA5nZ4BwR4fORCczctqXX3" Bounds="1498,810,20,19" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="1502,842,48,19" Id="OMtnN8azXsCM1EDJ4xgAig">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="MOD" />
                 </p:NodeReference>
                 <Pin Id="NFUvHlPqaTLLaKOJRJzTi6" Name="Input" Kind="InputPin" />
@@ -3384,7 +3406,7 @@
                 <Pin Id="NjOaTfF95VGLU0z0FpVbJc" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="1493,879,25,19" Id="GWQTBjQSr45Oz8VsJnS4yH">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="-" />
                 </p:NodeReference>
                 <Pin Id="LxwqD5tcmdcM9TmPZl0k99" Name="Input" Kind="InputPin" />
@@ -3424,13 +3446,13 @@
               <Pin Id="DNgsBthfvYLMcpdjxzgHuI" Name="OSCMessage" Kind="OutputPin" />
               <Pin Id="RCrbRD3I0UMOKb6u6Txdob" Name="Start" Kind="OutputPin" />
               <Pad Id="HIiJ0y41kv9NU0aGMEfSdY" Comment="Start Index" Bounds="356,1410,20,15" ShowValueBox="true" isIOBox="true" Value="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Node Bounds="498,1338,77,19" Id="NSH8SMdlsIBQA2aZfkAKQ3">
-                <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastSymbolSource="VL.IO.OSC.dll">
+                <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastDependency="VL.IO.OSC.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="UnpackString" />
                 </p:NodeReference>
@@ -3440,7 +3462,7 @@
                 <Pin Id="KyfRm3VDGsvNZYLSvI4SoK" Name="Next Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="496,1381,77,19" Id="FvGPfeK2O4RLp5dp313fre">
-                <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastSymbolSource="VL.IO.OSC.dll">
+                <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastDependency="VL.IO.OSC.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="UnpackString" />
                 </p:NodeReference>
@@ -3450,7 +3472,7 @@
                 <Pin Id="B0UgWa4H5HkM2feuA1fUBv" Name="Next Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="337,1657,62,26" Id="ObRXGj5mXgqPqYZcslyu43">
-                <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="Create" />
                   <CategoryReference Kind="Category" Name="OSCMessage" />
@@ -3461,7 +3483,7 @@
                 <Pin Id="Gru5d3pGdv1LYj6TOlEwTq" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="335,1457,70,26" Id="A5AGH8fMMBMMoVcGSoScO7">
-                <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Substring" />
                   <CategoryReference Kind="Category" Name="String" />
                 </p:NodeReference>
@@ -3491,7 +3513,7 @@
               <ControlPoint Id="IigrS91sLLfQOUzWUCHU5K" Bounds="577,1459" />
               <Link Id="FkhZg6oOo29NORMwHyL9bw" Ids="Me4BeLU3ClpMyEVVoQi3pL,IigrS91sLLfQOUzWUCHU5K" IsHidden="true" />
               <Node Bounds="586,1534,25,19" Id="AhU7c7kpEyDMP6JEXsRvBb">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -3502,7 +3524,7 @@
               <Link Id="F4sbTyPM7HcPzUuaRCgQpq" Ids="IigrS91sLLfQOUzWUCHU5K,Fd6Nx8TzTElO5ddTXP1Xhx" />
               <Link Id="VnFFcQFmpUkMUZJgp3ICjs" Ids="TYcd1Z1z7IZMH7VSFh1BJj,DpyG56YUHulNXvAqeRrSjv" />
               <Pad Id="SiMZE2ct5RnNAiVrmCXHLE" Bounds="592,1346,71,19" ShowValueBox="true" isIOBox="true" Value="&lt; address">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
                 <p:ValueBoxSettings>
@@ -3511,7 +3533,7 @@
                 </p:ValueBoxSettings>
               </Pad>
               <Pad Id="VlfuawcwglWNg7NWqk2C42" Bounds="619,1390,75,19" ShowValueBox="true" isIOBox="true" Value="&lt; typetags">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
                 <p:ValueBoxSettings>
@@ -3521,7 +3543,7 @@
               </Pad>
               <Link Id="C1WFJAOuNHtLn2Q8uPTtrE" Ids="HBIiorpxAjpMLc6DofxbP4,C3fJy9vuLA2LKtMCVdFRUL" />
               <Node Bounds="532,1514" Id="FJbgFLbgu95LKmZx3p1MRf">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="-" />
                 </p:NodeReference>
@@ -3532,7 +3554,7 @@
               <Link Id="CYgxeLpgqiwOjKzOqMqP74" Ids="B0UgWa4H5HkM2feuA1fUBv,Aosz9YecbAhMm0qsN5v7ye" />
               <Link Id="TLaSUwncBj9Of0PvmFKjf4" Ids="HBIiorpxAjpMLc6DofxbP4,KhvMxMF6G5eQHI7BqViOX2" />
               <Node Bounds="486,1550,25,19" Id="K91fhipnMiHP1UiTjq1jay">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="-" />
                 </p:NodeReference>
@@ -3543,7 +3565,7 @@
               <Link Id="Jzrigzojmn9LRBgcZbzqwq" Ids="IigrS91sLLfQOUzWUCHU5K,LDOzZibc5Y8QW4r7EPZq8F" />
               <Link Id="Kg76oyBp3USL5xtfTf4Evr" Ids="FJ3BFLbzWGFNVb2CHs1cdC,TnLPm8GKCoEO2g4vUXstNl" />
               <Node Bounds="405,1600,63,26" Id="MT5uUNNvkMfO0jCnZ5ojct">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetSpread" />
                 </p:NodeReference>
@@ -3589,19 +3611,19 @@
             </Patch>
             <Canvas Id="JMfou4I7Y0uP1Z4G9tFIc8">
               <Pad Id="BMXeoujrEp1LQjonLdIuR9" Comment="Year" Bounds="72,257" ShowValueBox="true" isIOBox="true" Value="1900">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="JPcmWGjXG1fNPGWYsEPiUs" Comment="Month" Bounds="155,257" ShowValueBox="true" isIOBox="true" Value="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="CJGyW4CLIgcLMQC9mnKuQ0" Comment="Day" Bounds="242,257" ShowValueBox="true" isIOBox="true" Value="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                   <CategoryReference Kind="Category" Name="Primitive" />
                 </p:TypeAnnotation>
@@ -3611,7 +3633,7 @@
               <Pad Id="MgQIi3RBE4CMuQA6PLKXdx" SlotId="CQz1oscAKzILfTFaDea6yN" Bounds="560,277" />
               <Pad Id="AYlXzGo4LovMGQAXSHV4Hm" SlotId="CQz1oscAKzILfTFaDea6yN" Bounds="177,424" />
               <Node Bounds="182,345,45,22" Id="TcG3x6YEQZVPRTCcCdFmvo">
-                <p:NodeReference LastCategoryFullName="System.DateTime" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.DateTime" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Create (Year Month Day)" />
                   <CategoryReference Kind="Category" Name="DateTime" />
                 </p:NodeReference>
@@ -3621,7 +3643,7 @@
                 <Pin Id="DOTNmPx5ezSLgdIs9xDaUy" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="698,649,51,19" Id="OnsWKpUbf1yPMOLY7A92NA">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -3630,14 +3652,14 @@
                 <Pin Id="FPxwX8XTD6SL4Lfb9v7bta" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="595,615,77,19" Id="Sj9J6X9phQ2LY9Gx6vzygK">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="IsLittleEndian" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
                 <Pin Id="OY9GIDtiQTGQHABS9UJ4bp" Name="Is Little Endian" Kind="OutputPin" />
               </Node>
               <Node Bounds="698,587,83,26" Id="VRDu0mBcrhvMBT7gkfpmvr">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="FromSequence" />
                   <FullNameCategoryReference ID="Collections.Spread" />
                 </p:NodeReference>
@@ -3645,7 +3667,7 @@
                 <Pin Id="K18RiNxBYnIMNQmX7eETfz" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="574,694,36,19" Id="MK2sYnlfTW0O9roYJmzMRd">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Concat" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -3654,7 +3676,7 @@
                 <Pin Id="E1ziWcOJIS2QDzkCVbs4Wx" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="574,738,52,22" Id="Btjkpiie3FFNk6yB07hv6Z">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="FromSequence" />
                   <FullNameCategoryReference ID="Collections.Spread" />
                 </p:NodeReference>
@@ -3662,7 +3684,7 @@
                 <Pin Id="CPUbWWbCwn8PRvcgWUrohC" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="500,593,52,22" Id="MHlzzTyocEiObWdGzuVhgy">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="FromSequence" />
                   <FullNameCategoryReference ID="Collections.Spread" />
                 </p:NodeReference>
@@ -3670,7 +3692,7 @@
                 <Pin Id="GQKtOLOOJpmNY43N0nqOPw" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="486,549,80,13" Id="TIVvYpQ3XmXOiHaRtUT6FN">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="GetUInt32Bytes" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -3678,7 +3700,7 @@
                 <Pin Id="HcKEyN3WTWINxcS2eSFGlB" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="500,658,45,13" Id="QFHNa4S4vqDNvbbSCV2vLS">
-                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Reverse" />
                   <CategoryReference Kind="Category" Name="Sequence" />
                 </p:NodeReference>
@@ -3687,7 +3709,7 @@
                 <Pin Id="SPuOkLLXVBkOo7KBZS05AO" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="508,343,25,13" Id="I7wMbWa0HyWQAS8eig7Yi9">
-                <p:NodeReference LastCategoryFullName="System.DateTime" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.DateTime" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="-" />
                   <CategoryReference Kind="Category" Name="DateTime" />
                 </p:NodeReference>
@@ -3696,7 +3718,7 @@
                 <Pin Id="SWIvJ8tl6ewLcXXqLVpjjC" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="488,426,71,22" Id="GvRmqsLioQrMTid6klbm3N">
-                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="TotalSeconds" />
                   <CategoryReference Kind="Category" Name="TimeSpan" />
                 </p:NodeReference>
@@ -3704,7 +3726,7 @@
                 <Pin Id="FNwhgdQ8rO5NDZ71QrRIf1" Name="Total Seconds" Kind="OutputPin" />
               </Node>
               <Node Bounds="575,421,66,22" Id="U6obG8P9NKlK924UgmHGrr">
-                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Milliseconds" />
                   <CategoryReference Kind="Category" Name="TimeSpan" />
                 </p:NodeReference>
@@ -3712,7 +3734,7 @@
                 <Pin Id="ICKDu0EE4gNLj2yRjynabF" Name="Milliseconds" Kind="OutputPin" />
               </Node>
               <Node Bounds="577,549,80,13" Id="AcfwTe1KFycMqPKi2IHfAS">
-                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.BitsAndBytes" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="GetUInt32Bytes" />
                   <FullNameCategoryReference ID="System.BitsAndBytes" />
                 </p:NodeReference>
@@ -3720,7 +3742,7 @@
                 <Pin Id="LfXTMCdI3bZPGOGQPd24cy" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="487,465,45,22" Id="TeKMrM7jESHNN4L2zR5NeD">
-                <p:NodeReference LastCategoryFullName="Primitive.Float64" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Float64" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="ToInt64" />
                   <CategoryReference Kind="Category" Name="Float64" />
                 </p:NodeReference>
@@ -3728,7 +3750,7 @@
                 <Pin Id="AJcuUF1xZXlQDePxuXLlOB" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="487,506,52,22" Id="PgCC7C9la8rPNnCwnvqik1">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer64" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer64" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="ToUInt32" />
                   <CategoryReference Kind="Category" Name="Integer64" />
                 </p:NodeReference>
@@ -3736,7 +3758,7 @@
                 <Pin Id="Mg2fSU9CnF1QFWwdE9FrJw" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="576,507,52,22" Id="DY1tS62kMAZMkHhbTxhOpD">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer64" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer64" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="ToUInt32" />
                   <CategoryReference Kind="Category" Name="Integer64" />
                 </p:NodeReference>
@@ -3744,7 +3766,7 @@
                 <Pin Id="AZBxktxmlcvLQDFORqbnDb" Name="Result" Kind="OutputPin" />
               </Node>
               <Node Bounds="576,466,45,22" Id="S8OZt0mtzNgOeSwh6y4qyU">
-                <p:NodeReference LastCategoryFullName="Primitive.Float64" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Float64" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="ToInt64" />
                   <CategoryReference Kind="Category" Name="Float64" />
                 </p:NodeReference>
@@ -3804,7 +3826,7 @@
 
 -->
           <Node Name="ArgsToData (Adaptive)" Bounds="83,131,121,92" Id="B2qBYQwGZSxQOVCEejccf0">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="TdKmliLviWzLw8Hm5n4OXH" IsGeneric="true">
@@ -3816,7 +3838,7 @@
               <Link Id="BZWrIEs60W2MF0CMkQdoa9" Ids="Tj6lalNBjrtQbpp6FiPAm1,QajpK1tTYNjMCe3R9Npbu4" IsHidden="true" />
               <Link Id="PewCh6uzzZfPbUpXxUgxCA" Ids="H77SHkdmeYYL2hhgD7Flbj,Tj6lalNBjrtQbpp6FiPAm1" />
               <Pin Id="He2CGgOBTCiLGsZi5TXGSP" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -3831,14 +3853,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="99,1354,179,200" Id="POsg35F20NMPPuETd1wntg">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="VmhcfClWcXkLMFF9OsLMRJ">
               <ControlPoint Id="DfdIivd17XGL1veTwZ8my4" Bounds="197,1388" />
               <Link Id="RfRsOBMaMHYMhQoNbQjw7f" Ids="NDc6EBz6iKWMLtJ5voXXXZ,DfdIivd17XGL1veTwZ8my4" IsHidden="true" />
               <Node Bounds="195,1405,71,19" Id="T8pNy7OuQQcNJI6EhBxKTK">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackFloat32" />
                 </p:NodeReference>
@@ -3849,7 +3871,7 @@
               <ControlPoint Id="OYFJTVw648SLabAPolczou" Bounds="115,1372" />
               <Link Id="Fn5rgziM1zyOj1sVP68bvt" Ids="T4k9XW72L0JLmsnJhAlDzE,OYFJTVw648SLabAPolczou" IsHidden="true" />
               <Node Bounds="112,1480,88,26" Id="PfFrN9QTYy9PZ5C4qbHECI">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -3860,7 +3882,7 @@
               </Node>
               <Link Id="Jp6wuQO62L6Px4Zfgbzi3A" Ids="OYFJTVw648SLabAPolczou,O771pcE1IJfNW9oT2QjJpQ" />
               <Pad Id="SMaSPxKpQtsMZ7Y8L2aRdO" Comment="TypeTags" Bounds="156,1452,20,15" ShowValueBox="true" isIOBox="true" Value="f">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -3870,7 +3892,7 @@
               <Link Id="EJSpfh673veOc5wFmu7cAm" Ids="D5tTW5PI2P8LYWQ2O1g1Tc,RRsyY0OpPMPO2nqPFKTtjk" />
               <Link Id="JpjI0VJugeKOkn97Mvmvv6" Ids="RRsyY0OpPMPO2nqPFKTtjk,O08vErRBewCLRXodFgGnIF" IsHidden="true" />
               <Pin Id="T4k9XW72L0JLmsnJhAlDzE" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -3885,14 +3907,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="92,276,176,165" Id="PgobsCuE6WSMIBFf0n3BBC">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="VLpSVm2o20yOc7siJjtgfB" IsGeneric="true">
               <ControlPoint Id="VT3zbrAEuHjNLi7W9zWaOa" Bounds="224,294" />
               <Link Id="VdW2z1zp9iLQQ8Xy6RTwY4" Ids="PK1Bbb9yVP4Lmck8faGisN,VT3zbrAEuHjNLi7W9zWaOa" IsHidden="true" />
               <Node Bounds="144,317,97,86" Id="MHPkKMARjNfNT82YMoqyW7">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -3906,7 +3928,7 @@
                   <Patch Id="D5DKEZjVmV4LG8PCzSfBZc" Name="Update" ManuallySortedPins="true" />
                   <Patch Id="JCs4s8UhHalMaw6L0Mkxhj" Name="Dispose" ManuallySortedPins="true" />
                   <Node Bounds="157,354,70,19" Id="DEVdLDsONYaPNFytSnltUY">
-                    <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                    <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                     </p:NodeReference>
@@ -3928,13 +3950,13 @@
               <ControlPoint Id="LZmOVYZeJRkLbSgQoJW2ne" Bounds="157,424" />
               <Link Id="Hpe0VhwqepULJq65ASFHrx" Ids="LZmOVYZeJRkLbSgQoJW2ne,FcJTd4oEtSZQbVdloc1tnU" IsHidden="true" />
               <Pin Id="DNGdqyW6NTiOYyU9InZMUR" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PK1Bbb9yVP4Lmck8faGisN" Name="Args" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Sequence" />
                 </p:TypeAnnotation>
               </Pin>
@@ -3947,14 +3969,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="331,272,160,186" Id="NIWG3l0iyI4PNJ7FAbrQSD">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="DBIZMmVL4XXLNZL1023Hxo" IsGeneric="true">
               <ControlPoint Id="PqgOF6EEQxLMNNMtoWWj3B" Bounds="411,290" />
               <Link Id="Dw0byl6XrR5Nn6wxNjjFVu" Ids="NykMynAqT0PLlPl8O5iaJh,PqgOF6EEQxLMNNMtoWWj3B" IsHidden="true" />
               <Node Bounds="343,365,71,19" Id="SyWUTRkpwo7LinmStAYWop">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -3964,7 +3986,7 @@
               </Node>
               <Link Id="NiwN8rEc3MFOUzqbKtbeJx" Ids="PqgOF6EEQxLMNNMtoWWj3B,JT62HWHwJNKMpY2Zxqnq0R" />
               <Node Bounds="409,308,70,26" Id="LNvK2wnVjeqM9PUpzyJPGs">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (2 Items)" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Split)" />
@@ -3975,7 +3997,7 @@
               </Node>
               <Link Id="NLC95qviGwoNmm5c17vP22" Ids="AhPhCdYh2S2OI67OIo2kD0,DkW7LYJnWN2NpTJDZvpCpN" />
               <Node Bounds="343,401,71,19" Id="NBqwUgzAvaXMLx9kQgZy3A">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -3992,7 +4014,7 @@
               <Link Id="IwhU6EB8SkTOeyUVDfQiWo" Ids="QTBrg4ncVLyOSbBUgfnqki,HUepKb7e2hPP1RD1sKvhN1" />
               <Link Id="Ichlve5zEbwNQG5wRdXdr4" Ids="HUepKb7e2hPP1RD1sKvhN1,Qyx1WHZMFw9NRDaDqWwEqd" IsHidden="true" />
               <Pin Id="ItqTS49p7oqMydqTtK7EWm" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4007,14 +4029,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="103,1619,179,203" Id="NB6WP4Ph5f6LrONGjVUNDf">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="QlqIPbr0UOcL7TP1jwtrBl">
               <ControlPoint Id="Era6cgZqgOmPIHLJ9DOIAg" Bounds="201,1656" />
               <Link Id="JiXJ7D0Jv8sNlaviHbA4lF" Ids="S7PTVvZWfEZOtJLVc1aec9,Era6cgZqgOmPIHLJ9DOIAg" IsHidden="true" />
               <Node Bounds="199,1673,40,19" Id="MYhFNY6Uf1uM24pOpScxCN">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackString" />
                 </p:NodeReference>
@@ -4025,7 +4047,7 @@
               <ControlPoint Id="RUwBKwtEKBwLIUPb06MqMF" Bounds="119,1640" />
               <Link Id="FUbbifyiFlVOBXEB00rwQf" Ids="MDBEdgGBIKdQP9eu4MvGF4,RUwBKwtEKBwLIUPb06MqMF" IsHidden="true" />
               <Node Bounds="116,1748,88,26" Id="ADm3vREPg1COB399olX17S">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4036,7 +4058,7 @@
               </Node>
               <Link Id="IDra8iNHV8aN5S5ExjotQT" Ids="RUwBKwtEKBwLIUPb06MqMF,QS7goBiLfIuNRyLRd0YSbU" />
               <Pad Id="O9zUj1NUxybPqR9WEVVGQI" Comment="TypeTags" Bounds="160,1720,20,15" ShowValueBox="true" isIOBox="true" Value="s">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4046,7 +4068,7 @@
               <Link Id="UfBSGxvHzzCLr5QGL7cBBo" Ids="Pq3GLKMrosbLx4wJD7Nbwv,IVvWeVWarVcN5znBmMvska" />
               <Link Id="TstI7fx9KZRPAQ5r96qc58" Ids="IVvWeVWarVcN5znBmMvska,EQlwGLg375pObatJ34fO5Q" IsHidden="true" />
               <Pin Id="MDBEdgGBIKdQP9eu4MvGF4" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4061,7 +4083,7 @@
 
 -->
           <Node Name="ArgsToData" Bounds="663,1349,181,201" Id="ThKSyy1NmCLO80vpDmxTAA">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="HXxIkxxG5bSP6GbNWQEMHL">
@@ -4070,7 +4092,7 @@
               <ControlPoint Id="CoMxgBSA3MJNRZpLfDCfN9" Bounds="679,1368" />
               <Link Id="CSPNTJJAhMmP2BcLYaD47V" Ids="S0qDjpvwOasN8CpbsNV5aO,CoMxgBSA3MJNRZpLfDCfN9" IsHidden="true" />
               <Node Bounds="676,1476,88,26" Id="DAMC6IE2668MlBVcwJLJHI">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4081,7 +4103,7 @@
               </Node>
               <Link Id="RDU2E8cLMduL0HmQT6perx" Ids="CoMxgBSA3MJNRZpLfDCfN9,Mi8dsS2achMMdRUwevxJ0K" />
               <Pad Id="UxehwNjYuiLLU1ULX9YSoH" Comment="TypeTags" Bounds="720,1448,20,15" ShowValueBox="true" isIOBox="true" Value="ff">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4090,7 +4112,7 @@
               <Link Id="VYkfyEm9xOvNbKbNixA183" Ids="N7AujxSNIgKLtRwNvTidA9,MHtIrMBYQSePyZfaFO7bwf" />
               <Link Id="IEL7lQClWdxNZ47BYJ0XEr" Ids="MHtIrMBYQSePyZfaFO7bwf,BrrdfvWGXFfMVhyzqsy2Zt" IsHidden="true" />
               <Node Bounds="760,1411,72,19" Id="RvnGQop9IWxLGUnhHHvL3i">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackVector2" />
                 </p:NodeReference>
@@ -4100,7 +4122,7 @@
               <Link Id="PTcUtV9UWt0OJ7z2zLFJgs" Ids="EziCChOY0IPQQczLK3mtJP,L9LUfQAEfE3MSkMka8qAbf" />
               <Link Id="VDSVfFPQsa0Nk5ZGnNpoAC" Ids="GxsmiHEXUYHNGoDzwLMdb2,H6Zb74oXprtLGUl1pA4p0X" />
               <Pin Id="S0qDjpvwOasN8CpbsNV5aO" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4115,14 +4137,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="550,271,160,218" Id="E7VDN1rCH3bP27TMldyVLK">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="DRhvK0Crj7sM3qhjfph0Lq" IsGeneric="true">
               <ControlPoint Id="HksgTQBOvJCMQXCGRjPTBz" Bounds="630,289" />
               <Link Id="QLikeCi3485NXYLg2kNyVI" Ids="C0JRBydlbThP3RIydfo2Cf,HksgTQBOvJCMQXCGRjPTBz" IsHidden="true" />
               <Node Bounds="562,364,71,19" Id="DikD51i9IHlMk9DAKvxRQv">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4132,7 +4154,7 @@
               </Node>
               <Link Id="CoKIzpujbakNxO1LNXEq39" Ids="HksgTQBOvJCMQXCGRjPTBz,FzUMiXeXE3aM7kLuAmidJO" />
               <Node Bounds="628,307,70,26" Id="I0NGWqdoSyQQaHrPWkLny1">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (3 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (3 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (3 Items)" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Split)" />
@@ -4144,7 +4166,7 @@
               </Node>
               <Link Id="NZfOKXWWQC3LqT5JIBH8YF" Ids="DslLP3JDNZwOujUllvCrua,FKauT7hZn11NdtaYHZRyDn" />
               <Node Bounds="562,400,71,19" Id="ApohKWtAYsoNpVwPH2awQj">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4160,7 +4182,7 @@
               <ControlPoint Id="NoZ3Z00PJQ1LbVWQgMbn9Y" Bounds="564,472" />
               <Link Id="N5jbvNyYqXTND3hyoB2vYG" Ids="NoZ3Z00PJQ1LbVWQgMbn9Y,OvrsCFXTCW3OAiyuhkQWZm" IsHidden="true" />
               <Node Bounds="562,435,71,19" Id="EWV2idPJs19NaL0hkFJTy9">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4172,7 +4194,7 @@
               <Link Id="PRjPhxzjIBqLnMgCwZVaIv" Ids="R6RkYD75hJOQNEq5A0JRZw,NoZ3Z00PJQ1LbVWQgMbn9Y" />
               <Link Id="Llb9g3BKkRyOLrxDJcJlxD" Ids="CZ93e0ffQ35QHyFKVV8UXC,EoZM0CZQSdvMR0A9wFxUNk" />
               <Pin Id="RH3jVnwLaBUO76Oemk57UN" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4187,14 +4209,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="82,1074,207,200" Id="IsxRApjCB0oLmn2xp8keW0">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="BprfE9S83V3QcPnJtmTJkU">
               <ControlPoint Id="RDzVDE0AaP9NjJdiKWkruj" Bounds="198,1108" />
               <Link Id="E4v2rMHVTMRL0YM6SPHbWn" Ids="Eve4YhwtUziOsM2bocxMAk,RDzVDE0AaP9NjJdiKWkruj" IsHidden="true" />
               <Node Bounds="196,1125,81,19" Id="OstzVCx4nsyNwV7V0CmBIN">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackInteger32" />
                 </p:NodeReference>
@@ -4205,7 +4227,7 @@
               <ControlPoint Id="LtTgkYDVstpLebxMSRyIE6" Bounds="116,1092" />
               <Link Id="NTArpfyKl1sPbBU8gxWma9" Ids="U0PEQZ0xAoDNSxENRE4vR3,LtTgkYDVstpLebxMSRyIE6" IsHidden="true" />
               <Node Bounds="113,1200,88,26" Id="Szxy4kJR7LuO7aFoJiWZhv">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4216,7 +4238,7 @@
               </Node>
               <Link Id="IZ6LkuXWeqdMs9RxZ0IJZA" Ids="LtTgkYDVstpLebxMSRyIE6,N3nuqAhSqfaOe5OaqAh4iD" />
               <Pad Id="C62EK3AGjBMPzql0CdspUZ" Comment="TypeTags" Bounds="157,1172,20,15" ShowValueBox="true" isIOBox="true" Value="i">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4226,7 +4248,7 @@
               <Link Id="TQ2xX7VZKsMNJayfM68YJp" Ids="EygQSP7cnuUMfvQwAdFywP,Sz9qOOdbgQwO1JSMrkknSm" />
               <Link Id="HOtHby0LgHyONz9YV9mACA" Ids="Sz9qOOdbgQwO1JSMrkknSm,KObASW20UrNMafd4277oeR" IsHidden="true" />
               <Pin Id="U0PEQZ0xAoDNSxENRE4vR3" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4241,14 +4263,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="111,1880,197,200" Id="CfzFlO67GvBPiintymy9jY">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="DRhI6Y0zXgHQCLlxlkf81N">
               <ControlPoint Id="ODRklJ7NS4CL4Zwv4lXKMt" Bounds="217,1914" />
               <Link Id="UVuQA14SMHPQIv7WQBmieS" Ids="OybJhFJaHJZPjv9tp9dohS,ODRklJ7NS4CL4Zwv4lXKMt" IsHidden="true" />
               <Node Bounds="215,1931,61,19" Id="NhXVlme2vqvO5MJjP6yYlK">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackColor" />
                 </p:NodeReference>
@@ -4259,7 +4281,7 @@
               <ControlPoint Id="NnycgDfrv7NNDfQhMAbMrF" Bounds="135,1898" />
               <Link Id="DfBypWWtkNWOjlK7Mnph2R" Ids="QsTG5h26cqCQNzvVLkQpoT,NnycgDfrv7NNDfQhMAbMrF" IsHidden="true" />
               <Node Bounds="132,2006,88,26" Id="EObpPMRgcdFQczfTNm9gNT">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4270,7 +4292,7 @@
               </Node>
               <Link Id="OdxXmu84eS7MFDlerEztBW" Ids="NnycgDfrv7NNDfQhMAbMrF,PrwKp4jUcdDNKeWunPnxPw" />
               <Pad Id="TLm2MuMk08POkjrAuo71pT" Comment="TypeTags" Bounds="176,1978,20,15" ShowValueBox="true" isIOBox="true" Value="r">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4280,7 +4302,7 @@
               <Link Id="F2hxSSY7AosQX4Odhg2tje" Ids="C3MXHBD6Ve3Nh8GvtDiYva,TV64DYpSBSoMYqc9k7Cpic" />
               <Link Id="DS8IlOXLRagMhx5VbueZ45" Ids="TV64DYpSBSoMYqc9k7Cpic,SSAhEdAgjDnPbxv3fcVNBo" IsHidden="true" />
               <Pin Id="QsTG5h26cqCQNzvVLkQpoT" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4295,14 +4317,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="373,1078,207,200" Id="JW0dL5D6YWOLUTtTj3tNfw">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="Fofw6fmZUkGNGwmYN9cIx1">
               <ControlPoint Id="ECLDVAxVUDXNyyLRqs1aoN" Bounds="489,1112" />
               <Link Id="IHzEGlh4hXBM9rpw9nT2rM" Ids="N2dxHA7eew3L3R2d0dIowf,ECLDVAxVUDXNyyLRqs1aoN" IsHidden="true" />
               <Node Bounds="487,1129,81,19" Id="JjVQCyIuafHQSFqEDgr5Ki">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackInteger64" />
                 </p:NodeReference>
@@ -4313,7 +4335,7 @@
               <ControlPoint Id="LWemwnX3m9PLQpVVgoudID" Bounds="407,1096" />
               <Link Id="KZNND78WOM8LW5xUQ35WI5" Ids="FcGW1hGefNSLvHd18Gopqp,LWemwnX3m9PLQpVVgoudID" IsHidden="true" />
               <Node Bounds="404,1204,88,26" Id="TAb7jdGkaMSNsRWDwqR0Dt">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4324,7 +4346,7 @@
               </Node>
               <Link Id="D9Ei0ONbK9mNvmLNYTFZ7o" Ids="LWemwnX3m9PLQpVVgoudID,JBJj7eIca41LZLOJxkRYhJ" />
               <Pad Id="AghpCZ8NCpcOQ0BAcOvx8T" Comment="TypeTags" Bounds="448,1176,20,15" ShowValueBox="true" isIOBox="true" Value="h">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4334,7 +4356,7 @@
               <Link Id="TklVuQr8O2nORC6F6ahz8v" Ids="MoWnY1jIv87Mew7Awz4vy5,It8HH7ZR7WZPsVc4Ckv3BX" />
               <Link Id="Vqlico7B9TVPw3JpXOQXYo" Ids="It8HH7ZR7WZPsVc4Ckv3BX,UpPvFEhH5eLPPhSssjCfzv" IsHidden="true" />
               <Pin Id="FcGW1hGefNSLvHd18Gopqp" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4349,14 +4371,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="379,1353,179,200" Id="TP8EYyuqT4ZPmFZYsH61NY">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="HQy8dMUJjUtQFWkbSYm9Qq">
               <ControlPoint Id="KVAKE3L9wfiN9yLS2gQouy" Bounds="477,1387" />
               <Link Id="EyhcTfweKVSOAHgjrmUUQa" Ids="Jmgl6RXiXTUMG9ficUKwNu,KVAKE3L9wfiN9yLS2gQouy" IsHidden="true" />
               <Node Bounds="475,1404,71,19" Id="OFTdMx9enOBPNTNOBkjHEc">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackFloat64" />
                 </p:NodeReference>
@@ -4367,7 +4389,7 @@
               <ControlPoint Id="DCkMr8LrRBwN0N6eWtU6yL" Bounds="395,1371" />
               <Link Id="AUEjam083X0LF6RV1NQla0" Ids="R2Rv2y3Xs6ML7c93IwmYM1,DCkMr8LrRBwN0N6eWtU6yL" IsHidden="true" />
               <Node Bounds="392,1479,88,26" Id="FFdnlgK0ysaMt2FeRIc5L4">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4378,7 +4400,7 @@
               </Node>
               <Link Id="BZHFIDllJ5MMwtqoc4aq04" Ids="DCkMr8LrRBwN0N6eWtU6yL,IjmFtjZSoeILV0og7VJSXT" />
               <Pad Id="FSiR88pxdoYPc4vFucm0td" Comment="TypeTags" Bounds="436,1451,20,15" ShowValueBox="true" isIOBox="true" Value="d">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4388,7 +4410,7 @@
               <Link Id="RfvQEX60UojQTQYvrdbgGp" Ids="V3VCcMVyYO8MKGVXZCj9jN,T3XW24r9GL8PXWlPOV9CST" />
               <Link Id="NJaoQgZVpHDLwXhflP4oRB" Ids="T3XW24r9GL8PXWlPOV9CST,NAhHI8wNA0SNlnOdoJ9sc8" IsHidden="true" />
               <Pin Id="R2Rv2y3Xs6ML7c93IwmYM1" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4403,14 +4425,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="394,1624,179,203" Id="KMb6mhe77cvP8vWMvV4Yor">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="CLTXpzlkYuvQNjVK8rtlLE">
               <ControlPoint Id="S7H8YRRBgUELKcZ0Face8P" Bounds="492,1661" />
               <Link Id="Va9g3zD1HqbQciyBzUg6SM" Ids="AULkK4YHQdzM8pEWbJokcw,S7H8YRRBgUELKcZ0Face8P" IsHidden="true" />
               <Node Bounds="490,1678,58,19" Id="Q61xPtUl0sVMz0Cz5fdrjk">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackChar" />
                 </p:NodeReference>
@@ -4421,7 +4443,7 @@
               <ControlPoint Id="OO6eI1UF1IJNiwQnKeICdP" Bounds="410,1645" />
               <Link Id="JdnirKxVLycOEZHJamSqcM" Ids="VdIGSREf3kLM2aylrOq85u,OO6eI1UF1IJNiwQnKeICdP" IsHidden="true" />
               <Node Bounds="407,1753,88,26" Id="UnE9GrrvR2dMpbs4Bj8Pjr">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4432,7 +4454,7 @@
               </Node>
               <Link Id="OHqyM5DTObMMFXb9LAcarW" Ids="OO6eI1UF1IJNiwQnKeICdP,JrmEM1RX3PMLRNbOn6K1Mk" />
               <Pad Id="T7lNehGYxMfNJhVQiIl0G0" Comment="TypeTags" Bounds="451,1725,20,15" ShowValueBox="true" isIOBox="true" Value="c">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4442,7 +4464,7 @@
               <Link Id="HccWTQYuBzeQcaZ6wG5fHI" Ids="TDtpXWlh0PGO7JeDCpq66v,IpapLJsNVKUOPOJm8P6LyU" />
               <Link Id="NvRbOoAHI3LM8M3MAzby4P" Ids="IpapLJsNVKUOPOJm8P6LyU,KurVAzpgG3vNnP5xIRdb3f" IsHidden="true" />
               <Pin Id="VdIGSREf3kLM2aylrOq85u" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4457,7 +4479,7 @@
 
 -->
           <Node Name="ArgsToData" Bounds="127,2135,190,200" Id="DKf1RxWJG3mMZ5BCnCiV4b">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="FVUUdI1MY4vM9alKdmW2Me">
@@ -4466,7 +4488,7 @@
               <ControlPoint Id="VEIbHsDWRLYOWEhSrSh87P" Bounds="143,2153" />
               <Link Id="EIzPe7itF5OLmshmiZcWwn" Ids="F1xt8yHT0aMLfvkvIQAzHW,VEIbHsDWRLYOWEhSrSh87P" IsHidden="true" />
               <Node Bounds="140,2261,88,26" Id="ORd0N75Fd8ALySh3U8pWpA">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4477,7 +4499,7 @@
               </Node>
               <Link Id="VB1GoptnfmaOPawIYmEYJC" Ids="VEIbHsDWRLYOWEhSrSh87P,O1uz1xP1TIcNdTsgY5vYNC" />
               <Pad Id="Pb4bxpf628gPmUt74iN4T1" Comment="" Bounds="266,2193,20,15" ShowValueBox="true" isIOBox="true" Value="T">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4485,7 +4507,7 @@
               <Link Id="QJlwROWvwEjQGNdDeRIZGB" Ids="AyFf0ZhtjTfL7g9xEVF7b9,P9OM09rf7ulP10OdClISeD" />
               <Link Id="UgyYmGGoNFELauWnMdlHag" Ids="P9OM09rf7ulP10OdClISeD,IdQHx64QPOsPOCjaSQnm60" IsHidden="true" />
               <Node Bounds="182,2222,45,19" Id="U6LszWNLIj5PvTcztMNUTi">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
                 </p:NodeReference>
@@ -4498,19 +4520,19 @@
               <Link Id="KmNE8uMUfKEOiXLQhe3NXx" Ids="QoejPT0i9RnO3r2aMl6Lvc,NCGnoBIK4cVQRJIDy2vPbJ" />
               <Link Id="SS7Z0047jIhOYQFqBcSATh" Ids="Pb4bxpf628gPmUt74iN4T1,HVY8RP8OmEJL6YxfW5cRj2" />
               <Pad Id="VgWlcsU1FbRNEHQAwIk3XY" Comment="" Bounds="265,2170,20,15" ShowValueBox="true" isIOBox="true" Value="F">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
               <Link Id="RF7EebUvhLyN3kb4ztBqKa" Ids="VgWlcsU1FbRNEHQAwIk3XY,MJg4XhNJymrOqQbSK1oA5o" />
               <Pin Id="F1xt8yHT0aMLfvkvIQAzHW" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="IkVbXcnZKsTMlL1ebKqmSs" Name="Args" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
               </Pin>
@@ -4523,7 +4545,7 @@
 
 -->
           <Node Name="ArgsToData" Bounds="142,2407,224,189" Id="SR6nTBzPASOQAgrGNv3C2l">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="H27k6LbRDMEMS3D6h5GkE7">
@@ -4532,7 +4554,7 @@
               <ControlPoint Id="SsJ4b27FVzTLDyk0QNX3Ou" Bounds="157,2425" />
               <Link Id="BbV0up1CWaKLD1Qa9PGwmc" Ids="OdKC7WRSR8CO4fajzf54bn,SsJ4b27FVzTLDyk0QNX3Ou" IsHidden="true" />
               <Node Bounds="155,2522,88,26" Id="LeVXD7TXXGlNgR7q5hG7EO">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4543,7 +4565,7 @@
               </Node>
               <Link Id="LclP6jXYQfwO5MCBZB6iZa" Ids="SsJ4b27FVzTLDyk0QNX3Ou,PEpZqBVsI3LQccPAj3ZOUx" />
               <Pad Id="OG7DLyeUSLdLOMttPqV8iQ" Comment="TypeTags" Bounds="199,2494,20,15" ShowValueBox="true" isIOBox="true" Value="b">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4552,7 +4574,7 @@
               <Link Id="QXJTgPJWupfOtt0wanLm8r" Ids="OGcao3myaUQQCZ5dOAoaKQ,BG2Hj1afQkHQYO1M4iaI6X" />
               <Link Id="LA98FVoHbk7LVNkd20tsW6" Ids="BG2Hj1afQkHQYO1M4iaI6X,C8ROlwSDki3MZBENq7TrxO" IsHidden="true" />
               <Node Bounds="297,2470,57,19" Id="AH0hEIOKlnxNtwW0Z8CbTd">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackBlob" />
                 </p:NodeReference>
@@ -4562,13 +4584,13 @@
               <Link Id="AyB6hSv57FCLSep6sX3olx" Ids="Q71UdNxwj76Nc34MvkM5Z2,UCcbZG85N2POB0nThFAVsi" />
               <Link Id="Epz8THcm1YxOcmqUNT6JKw" Ids="Vjl2GRCXFOMPbETYdfgrwd,VhhdwNAOwhcL3rTpVKr9Uu" />
               <Pin Id="OdKC7WRSR8CO4fajzf54bn" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CqNUHT43VTxNbfkOXtHFvS" Name="Args" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections.Mutable" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections.Mutable" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="MutableArray" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -4586,7 +4608,7 @@
 
 -->
           <Node Name="ArgsToData" Bounds="917,1349,181,201" Id="ThRNXfDvojWMH8HdxM5Msx">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="VLOoF7roVCnNZzpBj1Ebiq">
@@ -4595,7 +4617,7 @@
               <ControlPoint Id="B9z9soTNBxfMrE3Bf9VOXS" Bounds="933,1368" />
               <Link Id="PsB12Hh9A54LzVPbRRU1rB" Ids="SxYECMF3wpFOmgiNl0koeC,B9z9soTNBxfMrE3Bf9VOXS" IsHidden="true" />
               <Node Bounds="930,1476,88,26" Id="Q9fxs4T20OaNbB6NtfOYyV">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4606,7 +4628,7 @@
               </Node>
               <Link Id="UQgg4ELwgARP1AMJw6ptQf" Ids="B9z9soTNBxfMrE3Bf9VOXS,JBHBNvXJKllMTlQy6zw4FQ" />
               <Pad Id="BqGD9vuIUnMOHWxXpo1og6" Comment="TypeTags" Bounds="974,1448,20,15" ShowValueBox="true" isIOBox="true" Value="fff">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4615,7 +4637,7 @@
               <Link Id="FPI5fAVv527OWeBxBdM3nK" Ids="LS0WVIqMIPHMLjkySMK1Dg,CCgHvKedYIFPyfYbQ1mZbU" />
               <Link Id="H65442vd0RYOvH6ctc4xwx" Ids="CCgHvKedYIFPyfYbQ1mZbU,Tpp7ZASVPooLmI9D6SEoEL" IsHidden="true" />
               <Node Bounds="1014,1411,72,19" Id="QcZhA5dQ40aPyW7Atkt3QC">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackVector3" />
                 </p:NodeReference>
@@ -4625,7 +4647,7 @@
               <Link Id="KwvubA96jtbLHuqnSAUtcY" Ids="S943or7yUHFLuwXhJKxLN7,JWOpbajdomwMrZ2i1ZMfcT" />
               <Link Id="Q0P6gITIJuVQdtZqCmQrls" Ids="EwqxX7TuFv1M0bYakhvIWu,FdHJ2vioPxmNyZoB8JB1rV" />
               <Pin Id="SxYECMF3wpFOmgiNl0koeC" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4640,7 +4662,7 @@
 
 -->
           <Node Name="ArgsToData" Bounds="1194,1348,181,201" Id="VOdFlQ2Jr45MnSGn8aQP7h">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="LNqJY7VUFq9Ph5dXazv5oW">
@@ -4649,7 +4671,7 @@
               <ControlPoint Id="H55QsMDqwRMOXIleypRXRc" Bounds="1210,1367" />
               <Link Id="Arw2Xq9ltenMELCiEKsMiX" Ids="NSMitYTP47hNL6DvODvsGP,H55QsMDqwRMOXIleypRXRc" IsHidden="true" />
               <Node Bounds="1207,1475,88,26" Id="IeUVtTJY7dlOHqcHgb6xAS">
-                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="AddArguments" />
                 </p:NodeReference>
@@ -4660,7 +4682,7 @@
               </Node>
               <Link Id="GXxKnyfuUg3MFa4w9wCOaA" Ids="H55QsMDqwRMOXIleypRXRc,D1BefRcuiHeMR5EDvgYrbT" />
               <Pad Id="H7gUeN98gpGPui878NFXYD" Comment="TypeTags" Bounds="1251,1447,27,15" ShowValueBox="true" isIOBox="true" Value="ffff">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -4669,7 +4691,7 @@
               <Link Id="EnIUNwswRCHPzJxgwanUZm" Ids="AQUCuGXXlZoN8IIh6eDawP,LXXrD2wqKxKLdwYxIhKTQv" />
               <Link Id="RjElgTk1hQsMIfnmqyDUv5" Ids="LXXrD2wqKxKLdwYxIhKTQv,Kti6kMAbzocPZvRvHrUbUB" IsHidden="true" />
               <Node Bounds="1291,1410,72,19" Id="IiSIm3yJuEkMOH2FMchUBg">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="PackVector4" />
                 </p:NodeReference>
@@ -4679,7 +4701,7 @@
               <Link Id="FckV3EBSkrRQTSYlxqN2HX" Ids="T8HD99Awt5nQNWbpzlwjk9,Ktlf4xF9HaRK9jhBq98NPS" />
               <Link Id="AOwvEOsP6qqLPmES5hT1W2" Ids="DIImYcYJjc1QTnuGuDmRUY,DhH1523M8V0LXiomWYcC89" />
               <Pin Id="NSMitYTP47hNL6DvODvsGP" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4694,14 +4716,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="770,270,160,253" Id="Jop4FnQG1ZvL3GVWRBWFxv">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="NYDlvWACITdLuu6mC1wFAb" IsGeneric="true">
               <ControlPoint Id="FXfqwlYh3bHMQ1hPUpMsYD" Bounds="850,288" />
               <Link Id="AFzaffFJL6vPhi9Qwxz38M" Ids="BsCAEjLB8x4OFtVT8G3Nxt,FXfqwlYh3bHMQ1hPUpMsYD" IsHidden="true" />
               <Node Bounds="782,363,71,19" Id="JIhjiiCSs23OmMmAUVqGA1">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4711,7 +4733,7 @@
               </Node>
               <Link Id="V6ITjHHE60RQZHqCnfDolh" Ids="FXfqwlYh3bHMQ1hPUpMsYD,MrBajnrMsq7N3cDXI7I5jE" />
               <Node Bounds="848,306,70,26" Id="Cm1O24u9U3oQajoMd8bmhH">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (4 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (4 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (4 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Split)" />
@@ -4724,7 +4746,7 @@
               </Node>
               <Link Id="PbRdA8x4gnDO9xEZXjlgbq" Ids="TdgZFImcuFbLh9X3BpAfKI,NAp6WuWPnAEPz68avZDJE4" />
               <Node Bounds="782,399,71,19" Id="NZSlr9PEsVNL95B9lJlSR0">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4740,7 +4762,7 @@
               <ControlPoint Id="J3lyBW4qJi5LaIgFogGhmZ" Bounds="784,506" />
               <Link Id="Dv2gPYVnZlQOA79rshlqI0" Ids="J3lyBW4qJi5LaIgFogGhmZ,PRUfXnbEdYSPgjR7STgDyK" IsHidden="true" />
               <Node Bounds="782,434,71,19" Id="CkZWO5GbdMANGGpxj1PEDT">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4751,7 +4773,7 @@
               <Link Id="IxhvWUcerFdQNNFpxXaC8D" Ids="DjZ2thOQvhGMgiyuEvRNFm,VoSCPuGk1VkLNl0bczskbI" />
               <Link Id="H07k3iFO3MhPbVowlUagvP" Ids="HOJrdjkbbtmM292EzPz3Cj,IOS7Okmetr0M0C9XQrbVxb" />
               <Node Bounds="782,464,71,19" Id="SOtXowv3WyaPzVmbtABzFG">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4763,7 +4785,7 @@
               <Link Id="Tclvxix4nP7ORlnY0r3b6k" Ids="NIySaWOlEgGLUMREyeMMkc,IIEApMPHbinNLGsrhAwRmS" />
               <Link Id="EqEoYBEf4qZQQhPzZlkgWQ" Ids="T5wuDZWArnqQJuxw6z6zRy,J3lyBW4qJi5LaIgFogGhmZ" />
               <Pin Id="UuRofCUEwgtLAM7CdbqLBI" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4778,14 +4800,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="980,270,175,294" Id="Qy2SJZVi6UpMJlHsalSmgb">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="NKBtgNYL6WHM4x6irQUshs" IsGeneric="true">
               <ControlPoint Id="FwR3D4oG3gaL3kqacdhuXb" Bounds="1060,288" />
               <Link Id="UGnw76wvt77PmksDJ4DSDx" Ids="AkAtysKURCPLzm9VlaYUyq,FwR3D4oG3gaL3kqacdhuXb" IsHidden="true" />
               <Node Bounds="992,363,71,19" Id="IGTr0zBMd59QFp5TheikAm">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4795,7 +4817,7 @@
               </Node>
               <Link Id="S8l2OfLSHi0MzIlEMN3uKy" Ids="FwR3D4oG3gaL3kqacdhuXb,SCEQHixnGw7NQDHeZsdpAX" />
               <Node Bounds="1058,306,70,26" Id="AfIXlG8NBcoNKzfa22vD1w">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (5 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (5 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (5 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Split)" />
@@ -4809,7 +4831,7 @@
               </Node>
               <Link Id="SSxnFOFUBrjPsj9ipcXL58" Ids="HWypCOaZ3RzM9AjHt0eXDL,PKnLELmv6icOWOaySNo0th" />
               <Node Bounds="992,399,71,19" Id="S23WdrOO6pbLxAqWG0kcnK">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4825,7 +4847,7 @@
               <ControlPoint Id="Bgn2fkYETihMvIU8zFfIr3" Bounds="994,547" />
               <Link Id="JCyBJ2bnlJVMx4YFoUcB0I" Ids="Bgn2fkYETihMvIU8zFfIr3,GfvlUbEgyEjPiSN8x27Q70" IsHidden="true" />
               <Node Bounds="992,434,71,19" Id="OwGR1ENto99LiZODj18KL3">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4836,7 +4858,7 @@
               <Link Id="TorJONUhntxQL8zOFKXRDt" Ids="MDRFnXmU0FdOVXvQgZMs91,AdGtZmAEMRfL6S0YbQOgoO" />
               <Link Id="SVh1idz17e0PtWVXCV6E3U" Ids="ReiBwcryhrzL3sD7JnvPLF,NjPxZPY7jZkMMqSEcDpgCi" />
               <Node Bounds="992,470,71,19" Id="RwwC7u8acYZMSwcOjfp4aG">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4845,7 +4867,7 @@
                 <Pin Id="NF90feNq11dPL9bw16sfjp" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="992,506,71,19" Id="NbUF4Tv4ZrkOtJ2nqZ8P1p">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4859,7 +4881,7 @@
               <Link Id="Q89s1nbXUGpQX7pAo8oHT6" Ids="KgTcVBBfr7cPYPwGS9Dma6,GUsxh9abGyoMs4d3bUmHgR" />
               <Link Id="LWM4G4UPc8NLkQDN9i1q50" Ids="B6ohnvYUFxUPyVojWuc1c1,Bgn2fkYETihMvIU8zFfIr3" />
               <Pin Id="BwcEUXlKePGOLE58fZabTI" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4874,14 +4896,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="1190,270,195,334" Id="GXRScYm5iZYPx1sz6tReei">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="TfZ9I3QPZHKPiNafljDzxF" IsGeneric="true">
               <ControlPoint Id="RDvLYRawUOOODCicsO2XMb" Bounds="1270,288" />
               <Link Id="JkzTA1v6bcNL0AShomE9wC" Ids="Qc8AK7imPD7LH7Bd6IhGoE,RDvLYRawUOOODCicsO2XMb" IsHidden="true" />
               <Node Bounds="1202,363,71,19" Id="TpxoMBDexzRNLERhdmg5Wz">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4891,7 +4913,7 @@
               </Node>
               <Link Id="MOL3cQ81nIoLJhvBd3R7oT" Ids="RDvLYRawUOOODCicsO2XMb,BC3LjKHckRDQIzFtnnNsut" />
               <Node Bounds="1268,306,70,26" Id="VAhOAaEwL4MN3vU3JcwxO8">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (6 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (6 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (6 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Split)" />
@@ -4906,7 +4928,7 @@
               </Node>
               <Link Id="O0uIPZIpEmzNwKE2Pc2Q2J" Ids="UeeZW21ljmaMUzDl8gHVeo,S4MzS7wWvO1M7JA2cvRXdW" />
               <Node Bounds="1202,399,71,19" Id="RLKz9S1dKA7LPkmbGrHQ3L">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4922,7 +4944,7 @@
               <ControlPoint Id="PEbsPHJ94HoQCIzYfNLYvZ" Bounds="1204,587" />
               <Link Id="FN84wjoryHELkeQW7FKt3B" Ids="PEbsPHJ94HoQCIzYfNLYvZ,KUHtlz25eUBNXP0ZmCRMBF" IsHidden="true" />
               <Node Bounds="1202,434,71,19" Id="OFZ6jUYHrEUPBVzs6SrwvL">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4933,7 +4955,7 @@
               <Link Id="L8p3so5XP0VQFPAYr2dJj6" Ids="UDM7z5knpi6LvLxvl7YUNm,Od6mQUD6JmIPmLJaVpLpXQ" />
               <Link Id="LiStqrGc9NTLvhRMV8768F" Ids="LipoKQ7MLBJOhAHPTUqqdR,CDVa8nIwGtxM8DA2jlDpTQ" />
               <Node Bounds="1202,468,71,19" Id="L8lbXdPU7WdQbfRxYEYQBh">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4942,7 +4964,7 @@
                 <Pin Id="GkeN5HE98RANgYhCZoyGU9" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1202,504,71,19" Id="I6ZbJEeLNNoNsKslThRpAo">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4951,7 +4973,7 @@
                 <Pin Id="LRRYDGEIePvNsrpxl8JXDU" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1202,539,71,19" Id="GjujBdho4nGNrHv6GzIhHt">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4967,7 +4989,7 @@
               <Link Id="NtT6kPm29SuOWb0Ct8racn" Ids="QniUSG09WxAQd1OZcOCUZD,QCSzvVn7tNwOfVrAV7vO4j" />
               <Link Id="GqZMOcAByW4MUBpT3ExF0b" Ids="JlLGIZyCMZfNEeVVPNGHfA,JjFoi1ibpa3OBa5ElUsZoM" />
               <Pin Id="QKDQ6wt1Oq2LLbRoGU9F30" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -4982,14 +5004,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="1420,270,215,365" Id="BGt1DW1V9ZXMWhUuK9iqjy">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="AdbcA7fJ4AnLQd0qsYdu4r" IsGeneric="true">
               <ControlPoint Id="GgmqA9rEId2OtJIAQSvCpq" Bounds="1500,288" />
               <Link Id="SKFwRlmH6jdLuN5IeYOgkw" Ids="SKrI0x8AugwNIxobHUGYHY,GgmqA9rEId2OtJIAQSvCpq" IsHidden="true" />
               <Node Bounds="1432,363,71,19" Id="R5rtA7Ix9A1P2ea8VxUvV6">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -4999,7 +5021,7 @@
               </Node>
               <Link Id="HizMzTXue3bPja3OkzoUS7" Ids="GgmqA9rEId2OtJIAQSvCpq,B2JLFY4OvPgPCy0p9ObaTk" />
               <Node Bounds="1498,306,70,26" Id="NHr1Dk4U3PqNaztQgTRqIA">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (7 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (7 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (7 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Split)" />
@@ -5015,7 +5037,7 @@
               </Node>
               <Link Id="FMVbi7UAENzOR1Wwc1BViH" Ids="GIO4UmQI2vMQGUmIDtYzlZ,KgiTrOHTumBLyA6rZNsafn" />
               <Node Bounds="1432,399,71,19" Id="MYAyztlEf7rPTyC0DYTpce">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5031,7 +5053,7 @@
               <ControlPoint Id="VqxCCi207qqNNDcYX7wzOm" Bounds="1434,618" />
               <Link Id="UEnUjGpPvOKMOpI3MccBlW" Ids="VqxCCi207qqNNDcYX7wzOm,TQ7hd5PZIq3LvD63BmXRfc" IsHidden="true" />
               <Node Bounds="1432,434,71,19" Id="GY3t7fAGD18LIJoyhWRH0U">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5042,7 +5064,7 @@
               <Link Id="S9zN6Uw5XydOyUSi7hZyQv" Ids="K4czmPsRpiUPr8OrePtVEx,MeLicnj5m6ZLIWCTFm351y" />
               <Link Id="CIBlUeeFt6IMGXTVEnMoQZ" Ids="KGbvV7GFYmfLxhjjxEU9Qp,QklkO3j2iO0LAMBflC803Z" />
               <Node Bounds="1432,466,71,19" Id="Q5uJtw9ARerMUU3yKIB0vg">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5051,7 +5073,7 @@
                 <Pin Id="DAQHyudshIfNHeKQJaUjkk" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1432,500,71,19" Id="MKWlQHgMOYFQae2suk3x57">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5060,7 +5082,7 @@
                 <Pin Id="V5eS6hWu1AgPe3CcULotBt" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1432,536,71,19" Id="MD3nozctPrtLF6mtNcOaSV">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5069,7 +5091,7 @@
                 <Pin Id="QVzQ7zywpfgNMvYDIXiG8H" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1432,571,71,19" Id="RwOzScD6rsbLLXQ4tn37iO">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5087,7 +5109,7 @@
               <Link Id="DFB7GXIOxy4LVnxt6yznNJ" Ids="OOQCFf8XLXmMF4svMFcwKZ,BvE8YcUW7aBO11ykwZAQBA" />
               <Link Id="GAyDADhPwYBMawFpn5vywR" Ids="TKVvyzIMMFbPDgsqUP3ZTY,SpKB8JTYNJXLDqP1t1yuoS" />
               <Pin Id="BmF7h3gIEKwPqrwWY9bPs4" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5102,14 +5124,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="1660,270,235,402" Id="DfBLancb9R0PA29maPHdXg">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="U24ITS8OyPQM4CBAM40BlK" IsGeneric="true">
               <ControlPoint Id="PcvjfdqguiNMVkI4ZWNQQW" Bounds="1740,288" />
               <Link Id="OsGNX3pn80HK9sQIL7Uc1x" Ids="JcaqugDJvEoOB0InLvMzk9,PcvjfdqguiNMVkI4ZWNQQW" IsHidden="true" />
               <Node Bounds="1672,363,71,19" Id="AWtRMFwwBgcPFBGnzRb6Ia">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5119,7 +5141,7 @@
               </Node>
               <Link Id="KzeCojOfIXHPNXuogNJ8QP" Ids="PcvjfdqguiNMVkI4ZWNQQW,TytDFcAm3WMMcHXw6r8YA2" />
               <Node Bounds="1738,306,125,26" Id="SBVwdZrBZhXNiNlIAVMxlT">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (8 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (8 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (8 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Split)" />
@@ -5136,7 +5158,7 @@
               </Node>
               <Link Id="S8ylWkgUxXOPeZjNYTlCPU" Ids="MLvUMA9QqmcNyuNGsX95Qt,CLwhmLRMGYSOIgNwK8jhSw" />
               <Node Bounds="1672,399,71,19" Id="MRhOPAsDeimNYqDKDirtk2">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5152,7 +5174,7 @@
               <ControlPoint Id="TS2SqgQ5MirNND7q9y6Gxi" Bounds="1674,655" />
               <Link Id="NGtQYV35NtqLNNNeECwEPj" Ids="TS2SqgQ5MirNND7q9y6Gxi,BNU2mu1Zk7oMOTKPNAeFWK" IsHidden="true" />
               <Node Bounds="1672,434,71,19" Id="Cwo2YdFXWUaOybMA5guIEW">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5163,7 +5185,7 @@
               <Link Id="KqVhEiyOXYuL6o3DCPdC5e" Ids="KiHBtBuYSmLLcgMSDHzqko,TjhuFltIaLAMfHPZICyKza" />
               <Link Id="GSz20dTQ3eVOGoyTiUx2IN" Ids="Hgc4EUlbtv0OQY7EieMdWC,RATMqajcKjcNUTDcGgih2k" />
               <Node Bounds="1672,472,71,19" Id="LTJK0XZFvc5LWvK3O2aNyC">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5172,7 +5194,7 @@
                 <Pin Id="PkvCVG74OrvMtTFd2zTRMS" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1672,504,71,19" Id="R4DUuHgd4HBNOcNosaRWDm">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5181,7 +5203,7 @@
                 <Pin Id="LsVPLmqMYyOLe3LPeePogc" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1672,538,71,19" Id="NKIPKOZY965MgQriIwjtu8">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5190,7 +5212,7 @@
                 <Pin Id="QuCkiTqquhpLczGzatDp8G" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1672,574,71,19" Id="KfpnbI6Ky9iNjkXq5mZsUR">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5199,7 +5221,7 @@
                 <Pin Id="PVoGcaqctpfOGL5NabNiI9" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1672,609,71,19" Id="TcFbWMs15T0L7270m11GFf">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5219,7 +5241,7 @@
               <Link Id="JGLe60s8FR1M9qEQgZwWkL" Ids="Ueai7Ij0ZGfMQ9TPFkMb5D,USQyKA9UOzEM4h3Q4FEM03" />
               <Link Id="NvPChedMRIdLY9d9SiYuDm" Ids="NpNg3t2Cfu3OztfUMPW3g9,VTwoLZeJCABOFhgMMDsUu1" />
               <Pin Id="GbtyeivguBfNpYXPg0NniH" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5234,14 +5256,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="348,732,160,186" Id="PWKdz7Kt1JmNR8bOMrEI9j">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="MQwqtToAL4xMj1mePyKpal" IsGeneric="true">
               <ControlPoint Id="MAGrh1AYuuPLrEmWMdFmM3" Bounds="428,750" />
               <Link Id="LbgEG0VImwDLT6ZX1rrGfW" Ids="FJZLc72sXwkMGAjdMzAUcg,MAGrh1AYuuPLrEmWMdFmM3" IsHidden="true" />
               <Node Bounds="360,825,71,19" Id="F36l6gYGiGBNFEqHz1mzhH">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5251,7 +5273,7 @@
               </Node>
               <Link Id="Dz9Xd12PR1kPxGJbGs9goV" Ids="MAGrh1AYuuPLrEmWMdFmM3,IeQM5G9m3BIM9fzTC1pi4o" />
               <Node Bounds="426,768,70,19" Id="AmV63jzgxUUP8v8Lh5Kdns">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (2 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -5262,7 +5284,7 @@
               </Node>
               <Link Id="VXCSXcyTEzcPFVpjG9gGbd" Ids="HNuobmKQRDwMza0Vio6OBf,KLJH2NnRjzaQdKBnLDIdOn" />
               <Node Bounds="360,861,71,19" Id="B8O9z3L8rKHPUrFJx1et7u">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5279,7 +5301,7 @@
               <Link Id="LOsQ4gAK29BOV9uGPRy6NO" Ids="ROs1a5hURC8NMWN1rp8Y2J,VgqJPZ1WropQafVsBo8x8N" />
               <Link Id="SYB5LtOXdtqMkFOcA7YtSu" Ids="VgqJPZ1WropQafVsBo8x8N,EzUcpTZmsR6QWTjUHH4Lek" IsHidden="true" />
               <Pin Id="I3TMCYlteitMOTnD3T85oO" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5294,14 +5316,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="561,731,160,218" Id="D3VMHyu4VqqNo8Rc4kDx4R">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="IxMueG99qg5PqeSonBp1WJ" IsGeneric="true">
               <ControlPoint Id="RMpm7up7itgQAs42OYTvxa" Bounds="641,749" />
               <Link Id="Qiip5c9pKuxPNy25cMsLuG" Ids="GoNYTe6yxnHLgLwQz1SrFN,RMpm7up7itgQAs42OYTvxa" IsHidden="true" />
               <Node Bounds="573,824,71,19" Id="Gjy4apAfCkeLkWLf76z5Dv">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5311,7 +5333,7 @@
               </Node>
               <Link Id="O4Zo63VQ6o6Lt8ZoEYBjxT" Ids="RMpm7up7itgQAs42OYTvxa,NDrSgkfvShCOW7RHswCyDY" />
               <Node Bounds="639,767,70,26" Id="E77bYs5SwjTM6lFg4dGCOo">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (3 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (3 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (3 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -5323,7 +5345,7 @@
               </Node>
               <Link Id="CZluDVRu6PCLMm5qVGqgLt" Ids="IKMy7jmbngGN9I7TZlRF2N,TAjXkTSdYfINMMFblkPJD9" />
               <Node Bounds="573,860,71,19" Id="Je4prp7yvusMXqUNaJ7kEJ">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5339,7 +5361,7 @@
               <ControlPoint Id="I14tsg55nzDPZcwmEFCTZy" Bounds="575,932" />
               <Link Id="SP9iyFOmsACOpHvkiM0qc1" Ids="I14tsg55nzDPZcwmEFCTZy,SM6ikMPkxA2MmdUWtmM6Qk" IsHidden="true" />
               <Node Bounds="573,895,71,19" Id="JgEAIfukEibQMdOtotCBL0">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5351,7 +5373,7 @@
               <Link Id="AsDjptfes3jPxjwiYK1hG3" Ids="EKoRKN5hHVoOOxp0joBTLO,I14tsg55nzDPZcwmEFCTZy" />
               <Link Id="UcRuZXHiNBSMpdhqurWEGi" Ids="TxibxEgzp5vLJv9DdkPgmN,GGkgAy73RRrQNNtgFlnmaP" />
               <Pin Id="UPgwyzK6XEGK9mAzMi8mMM" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5366,14 +5388,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="781,730,160,253" Id="Lyko5a5oVjiQSsntaMmgES">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="STue8G3jaujLbmvuEvsDTY" IsGeneric="true">
               <ControlPoint Id="LEVXxiQwN14PLYKRv9vNoR" Bounds="861,748" />
               <Link Id="Ue0Rwzhu3jvNLPiyA74oWN" Ids="KaPZJKAq0BKLTBAnIU7vxv,LEVXxiQwN14PLYKRv9vNoR" IsHidden="true" />
               <Node Bounds="793,823,71,19" Id="VQ6XCEPCqygMCWtTNa0eaN">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5383,7 +5405,7 @@
               </Node>
               <Link Id="Bp27kMK5CzJNJlFmykfSa1" Ids="LEVXxiQwN14PLYKRv9vNoR,NDFk87RlNCRNl2XSqaKvez" />
               <Node Bounds="859,766,70,26" Id="CxA4WDwMktZPfoyxJUWEw4">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (4 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (4 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (4 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -5396,7 +5418,7 @@
               </Node>
               <Link Id="Aj8xPxq5BBLNYLN0U5VCV3" Ids="CzYHlTaDcMEOpo9sO8hYSV,RHFwuaOfHtfPmTpXIZe9z9" />
               <Node Bounds="793,859,71,19" Id="FmvGUmhWycRO6F2LMtfbS3">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5412,7 +5434,7 @@
               <ControlPoint Id="I9lbPyeIfNDPZ5XJiz73xA" Bounds="795,966" />
               <Link Id="Lm91KieYOh2NBcVbN8Eu6w" Ids="I9lbPyeIfNDPZ5XJiz73xA,Hvo0SCUzHFQOLCuJ9SdZRR" IsHidden="true" />
               <Node Bounds="793,894,71,19" Id="MLBUh8ETVjLOCJESm0X5P2">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5423,7 +5445,7 @@
               <Link Id="OL1fUwBcIB2OZfSIfXjqNq" Ids="AF5a4KAnJnmLxnOkKkXs3i,QlDZGWiMV5oOQRtJUEKTJ8" />
               <Link Id="Egpo7MmqAIGP6vT9HUCNAV" Ids="J1bf4eFZNcAOcmYD2LLsWR,NZDHrpFnLs4NQFvN6nknWu" />
               <Node Bounds="793,924,71,19" Id="OlugoK9lHbyPTtEPD2fGwP">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5435,7 +5457,7 @@
               <Link Id="MaL4xYZ9CuvMjd7GwpxFxH" Ids="VwiK247qD7ULceReadixWd,DejHYRRpI92LJMC4Pgtzub" />
               <Link Id="G0sUFmGHDnpPBS3nKwPcav" Ids="INXRSA7fDnVNknvlDmysOH,I9lbPyeIfNDPZ5XJiz73xA" />
               <Pin Id="B17gg3sjZhaPfRLQuLXgjS" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5450,14 +5472,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="991,730,175,294" Id="I5cfyJxDyXWLA0fqinhKHh">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="JUNWJy9ncuVQUInmztf9bq" IsGeneric="true">
               <ControlPoint Id="REYH9gRsTa5NNAwIcRl6TS" Bounds="1071,748" />
               <Link Id="IE8hE2XYJLEK9us7zRPTi5" Ids="O1cPslYqoCiOCJjtJlK1dY,REYH9gRsTa5NNAwIcRl6TS" IsHidden="true" />
               <Node Bounds="1003,823,71,19" Id="FIRfNy61D9ALSUaNDtd98O">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5467,7 +5489,7 @@
               </Node>
               <Link Id="SO597yLiTeUMXVJteJ2xxn" Ids="REYH9gRsTa5NNAwIcRl6TS,HBjrbOY8X9LM9CqMzD0mpU" />
               <Node Bounds="1069,766,85,26" Id="TurCs7yj7f5NoIUS2kkuS1">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (5 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (5 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (5 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -5481,7 +5503,7 @@
               </Node>
               <Link Id="VQaaEn531zeQR6NEODJHRx" Ids="EfYcIl6FrsXNMlGbgFpK2G,E6FQlLBQGPeLPq7kc7Zh1w" />
               <Node Bounds="1003,859,71,19" Id="F44dKWxSa2RL6z8IHXXlKV">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5497,7 +5519,7 @@
               <ControlPoint Id="AHhoOnBHtVNQdWSJD9wdwu" Bounds="1005,1007" />
               <Link Id="Ll68lg8YgnXQaghTlb88vi" Ids="AHhoOnBHtVNQdWSJD9wdwu,J6SaqZtQtP8Mf2TM4F7lAg" IsHidden="true" />
               <Node Bounds="1003,894,71,19" Id="OLdw2PpfxJfPx8kc0cS5SO">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5508,7 +5530,7 @@
               <Link Id="VGdhAF3yhQhMZpkbpNbyJi" Ids="T8p1ifRw8G5LFOP7eZiQkW,DPW5MyODbYGLzdNwaTG4fT" />
               <Link Id="BwmJrkzvcBhOfpEPTVdMuI" Ids="SG8RROgNcFQQHhh5Y7L8UY,PCv9GvwEGlyO1IEfvmWE3S" />
               <Node Bounds="1003,930,71,19" Id="MtjEsiUWsiEOLAP0DaFxv0">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5517,7 +5539,7 @@
                 <Pin Id="Rkx5fzG9WGiMHHsg1bUjVW" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1003,966,71,19" Id="DdDUPetMjurOANJHV5N1iB">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5531,7 +5553,7 @@
               <Link Id="KovKWaMQC8xO1PGjBTcDVH" Ids="MtIO8Zb1SZMOvtqBoUec7b,NiXPBFSHLEbPORu0HBQzAv" />
               <Link Id="Qhdism8r8G3PBzyp9mCobY" Ids="QMXlzRZzzq1QJXaKVLpbpi,AHhoOnBHtVNQdWSJD9wdwu" />
               <Pin Id="NTAbVryI3yRNOx9EF2r6bh" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5546,14 +5568,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="1201,730,195,334" Id="JavaFxkoR5UMmMRgVV5iNF">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="AbVTOPBz4LrQT0xtOVsHE3" IsGeneric="true">
               <ControlPoint Id="UlREdH28RM6MYwXU8uHasT" Bounds="1281,748" />
               <Link Id="N6vWhhYWKuRLhXN3JGHwAe" Ids="D4eGmwYa0yrNKQPLnAj3Hb,UlREdH28RM6MYwXU8uHasT" IsHidden="true" />
               <Node Bounds="1213,823,71,19" Id="OjPDP81rRJiMxpd0SRWTVy">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5563,7 +5585,7 @@
               </Node>
               <Link Id="OBwIZKpLar3PxYduhdEle7" Ids="UlREdH28RM6MYwXU8uHasT,V2K6naVmjhkPQABuiLNFe7" />
               <Node Bounds="1279,766,105,26" Id="LtE9htl5LnIN6QtUQs1uJR">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (6 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (6 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (6 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -5578,7 +5600,7 @@
               </Node>
               <Link Id="I3CqeLvXuZtP9igihRVVZK" Ids="ERO4sWEr4A7O7qFPAy0GAd,HuKjur3YB1bOmg8IChXKV6" />
               <Node Bounds="1213,859,71,19" Id="EcGycU0XoGnP4DRqmCdLxi">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5594,7 +5616,7 @@
               <ControlPoint Id="IQzAaQY63FGMqp8W7N1KjK" Bounds="1215,1047" />
               <Link Id="EWnbdMZXKlMOdG4cTas6H4" Ids="IQzAaQY63FGMqp8W7N1KjK,GrVlkw1fWZHOpylV5bwiSZ" IsHidden="true" />
               <Node Bounds="1213,894,71,19" Id="IL3vBlnX8WrN07qJHtJD6c">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5605,7 +5627,7 @@
               <Link Id="Di469RzjfS6P8wAM6JzdKs" Ids="ACdGAE6GF2xOZCdtd9q9u7,KCYC6PN8XzAPqj33AmF4HZ" />
               <Link Id="IXrLWT1Vw2wPfwJs9zSNKn" Ids="H1zyDNMaG2KPQ8FkDo868x,L3NmUwaE1ICMKeylSGxnn3" />
               <Node Bounds="1213,928,71,19" Id="VATgG0qXujmPBsy0uB2qMT">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5614,7 +5636,7 @@
                 <Pin Id="HjwXV4ynxolO4QvUp2qKIV" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1213,964,71,19" Id="BJOS3WgL6f2P53LFF98KtB">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5623,7 +5645,7 @@
                 <Pin Id="JICoLGxhdoePBivqPPp80H" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1213,999,71,19" Id="RB2CVBCFzWXP4ZbLwblPIx">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5639,7 +5661,7 @@
               <Link Id="R7iGOmjb6V4O8IrXtTmGHp" Ids="DyQFMZYkoo9OcTUETVaTYo,USzTMyxBQoRLps9oNqUNVu" />
               <Link Id="PW5Yh1pssHWMO71O9DrKVL" Ids="DappMBYbFI6NZrxXuMwsnG,Q8yZP4TL5unNG9siaC9BUW" />
               <Pin Id="GuMjTHEgpIZPfbDlHjopsC" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5654,14 +5676,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="1431,730,215,365" Id="GFeF1SwxUUvQDaxUBaHohS">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="VU96BxiKcL3PXSww5IDnlg" IsGeneric="true">
               <ControlPoint Id="ChUcDMQbSjeN5sRx3SlGiN" Bounds="1511,748" />
               <Link Id="Js9F86ILhu8Nx6N8RoI3Lu" Ids="QNPh3dA5HBUOE1EFufMZMT,ChUcDMQbSjeN5sRx3SlGiN" IsHidden="true" />
               <Node Bounds="1443,823,71,19" Id="Ia8kgjE9NVMOKUyXEQUMDd">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5671,7 +5693,7 @@
               </Node>
               <Link Id="RQLPZuX3lMWMaUJWXDZZhf" Ids="ChUcDMQbSjeN5sRx3SlGiN,De4yl6YcjVCQHOtvXtf6Ed" />
               <Node Bounds="1509,766,125,26" Id="QzWQsfkoUT2PlrNeovMlMc">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (7 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (7 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (7 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -5687,7 +5709,7 @@
               </Node>
               <Link Id="FfbwO5gNYtLLHIya6AB1ey" Ids="R7Bjs16ZNeUM4vrac8lq8O,B41A0YvXJtMQNMFO2GrWBG" />
               <Node Bounds="1443,859,71,19" Id="Avx7lTluNw1NYOoLBQysup">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5703,7 +5725,7 @@
               <ControlPoint Id="NuopW37uZOmPI10LAVmpT3" Bounds="1445,1078" />
               <Link Id="CMgggxadx9fMuADcJz4Kut" Ids="NuopW37uZOmPI10LAVmpT3,HodMmp9B3ysPG18Voxz1nE" IsHidden="true" />
               <Node Bounds="1443,894,71,19" Id="KtDSoAHR0fHMNQ7lpkS0F9">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5714,7 +5736,7 @@
               <Link Id="Shs7xZviLwBQRsRUHXVI3W" Ids="VqMDb3u6OGtNES3JdcXprH,PIFk0ABAgj3LxZj0qRl3mK" />
               <Link Id="UWXxZRf3YQvQNbwBkkgh6H" Ids="QE8GF1I8UwbMVGEyT45LOZ,Gj8NsHP8mUtNoEtgBHC2d2" />
               <Node Bounds="1443,926,71,19" Id="Dw3EWYXg7aZPYLKbzBqhJt">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5723,7 +5745,7 @@
                 <Pin Id="UlYwKSwKYxcMs8rj9PEdac" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1443,960,71,19" Id="BwFtyzyoCoXMRfygGWRgiZ">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5732,7 +5754,7 @@
                 <Pin Id="NrIYVRjOapPQUlVecRQOYZ" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1443,996,71,19" Id="HD95AXXEQQ5P7KgKXjPmZq">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5741,7 +5763,7 @@
                 <Pin Id="NJslfj2VplPLxB6mXVmlJI" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1443,1031,71,19" Id="VdaitkaPKVhLQJ6yvjgZAe">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5759,7 +5781,7 @@
               <Link Id="H0OHyDX3PsNMTsWe0DjVsU" Ids="RaJyNX5itbtORFm9lhsZVN,DBJlCB5V4TDNwoMhaoRFh8" />
               <Link Id="CSil6GcxrZdLEVkbPoHo5h" Ids="DqDAXZR5DV2LnXM3H7rhOP,KSMFMpixvrpPqyDzkXJrH1" />
               <Pin Id="QyqDbjvPxAuOGR4HoM7ia4" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5774,14 +5796,14 @@
 
 -->
           <Node Name="ArgsToData" Bounds="1671,730,235,402" Id="B29WYI1zReHLFfoRmvjige">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="MErxOhg6VcYOk7lwmG5cXW" IsGeneric="true">
               <ControlPoint Id="UjInb9I4TOwL2XrMYA5LL0" Bounds="1751,748" />
               <Link Id="NBh3gtQQ6QmLvsqBQZfhen" Ids="QoMfmZARAYbPFHTPJo3QDq,UjInb9I4TOwL2XrMYA5LL0" IsHidden="true" />
               <Node Bounds="1683,823,71,19" Id="NVyRv1PmnNpLXNzapm6DlU">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5791,7 +5813,7 @@
               </Node>
               <Link Id="GJrwqHc7VBnOi1O2VfCqch" Ids="UjInb9I4TOwL2XrMYA5LL0,JPWdYUtbpXUMqa9F6XAjfy" />
               <Node Bounds="1749,766,145,26" Id="LpjcNF0rHGyMBzyft4D1BV">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (8 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (8 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (8 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Split)" />
@@ -5808,7 +5830,7 @@
               </Node>
               <Link Id="SwuKSG3gorNNNrNolHm7n1" Ids="TYFW6W65TzENKaTekA5bRG,VdcBGzEa0q6PJiPjO50ash" />
               <Node Bounds="1683,859,71,19" Id="HvYmli11mEVM6NBDn8JS5B">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5824,7 +5846,7 @@
               <ControlPoint Id="B2EgmulbMYPPPMtZgjKzSJ" Bounds="1685,1115" />
               <Link Id="ABaSLqYt2srNDWaG1xG8ON" Ids="B2EgmulbMYPPPMtZgjKzSJ,HXO0TAasOEROCq13886y4w" IsHidden="true" />
               <Node Bounds="1683,894,71,19" Id="DLQVEOsoz61L9IHgjDH18i">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5835,7 +5857,7 @@
               <Link Id="C3gGST7muk7N2ooRjeFDV4" Ids="GsHEFHMLg94MH5iX0XQEl4,B5EDKfrSjKPQIQ1NMbV5Db" />
               <Link Id="I3m23DzAOnGNZOKtALdiTX" Ids="BbfuF7oClBkOi2jIJwIgaA,NVOpVbEEBb5PyHhBYRZ3oJ" />
               <Node Bounds="1683,932,71,19" Id="T5AfJY3kibsNScoxsxLvD6">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5844,7 +5866,7 @@
                 <Pin Id="DVGhIT5zcgBPYh94RHU7JD" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1683,964,71,19" Id="N0nRzY7S2IZNxrviiwGLfT">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5853,7 +5875,7 @@
                 <Pin Id="TTPChWGjNmcNs8AP9JF0ln" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1683,998,71,19" Id="Vueg9ucKRt1P1uVVn9HL7T">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5862,7 +5884,7 @@
                 <Pin Id="Ks24QVrxAPYNaMO8gjZwME" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1683,1034,71,19" Id="GOYW7sitk4pQYVpOJorlDd">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5871,7 +5893,7 @@
                 <Pin Id="Kj3RLRP44AcOGSNgkAjX4j" Name="Context" Kind="OutputPin" />
               </Node>
               <Node Bounds="1683,1069,71,19" Id="QYGHDjP93GRNxriDrL8IQc">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="ArgsToData" />
                 </p:NodeReference>
@@ -5891,7 +5913,7 @@
               <Link Id="DTEiWRf7yEXPaAICdD44LG" Ids="MWfKbQX4ZzXOu06NKbgUdT,U9vgRmhk6pIL9Dg2yrupjM" />
               <Link Id="HLSiSsGNNlpLtTfIcl0DZc" Ids="L2c90ufIUjOMIopOj68pXh,LTVERgVgsIcNbT3RCL7FSJ" />
               <Pin Id="Pdoz4o7b7dAM6sV15EIVyA" Name="Context" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:TypeAnnotation LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="TypeFlag" Name="SerializationContext" />
                   <FullNameCategoryReference ID="IO.OSC" />
                 </p:TypeAnnotation>
@@ -5908,7 +5930,7 @@
 
 -->
           <Node Name="DataToArgs (Adaptive)" Bounds="99,121,366,91" Id="Un4gvHn6uZCMn9WiGLjnxv">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="L4oSvSvBcm1LZXGz0q3Zvo" IsGeneric="true">
@@ -5927,12 +5949,12 @@
               <ControlPoint Id="Iu50lQkValTMapKmPmXKMW" Bounds="246,195" />
               <Link Id="MRCH1vE6zhvL8e5oWUZqcS" Ids="Iu50lQkValTMapKmPmXKMW,S3TTMHRZB3HN7zChThsRLf" IsHidden="true" />
               <Pin Id="GxXTMbQoFmjN2yvpxGVoAp" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="P6IbpXAYYkNNogb4EYY33H" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -5942,23 +5964,23 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CSmqRS0LVdLM3oZUL0mmh3" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="L3l6ZpmxSQuLeDIXOrSUQV" Name="Byte Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QUwandi7I8xPrErTKqYuHV" Name="Args" Kind="OutputPin" />
               <Pin Id="S3TTMHRZB3HN7zChThsRLf" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="FyVfPJPKqs8OHLy1kcQYWa" Name="Next Byte Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -5970,7 +5992,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="164,2330,358,128" Id="B74NfdQMNX6Nv1l6BygbJc">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="SQM5Ew2Dr1BNkL2aWTHwzo">
@@ -5981,7 +6003,7 @@
               <ControlPoint Id="L95wIpl85hdNXgVksZHlk9" Bounds="178,2441" />
               <Link Id="HqU4ltIXtdtOz9UGn2J6fp" Ids="L95wIpl85hdNXgVksZHlk9,Vwyuwa9uMUnNHUJlQcgJVB" IsHidden="true" />
               <Node Bounds="176,2384,84,19" Id="GBdN4DnVYxeQAMtZppsBOy">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -6000,7 +6022,7 @@
               <Link Id="VedS8sQfkyROljcaq2J9bk" Ids="TUi8uTEx9GBMmM2OQCs8qL,S7qbVvdtsiNMcDQAr1Hbsz" IsHidden="true" />
               <Link Id="IMMckJsYd1bPjSLsaSff0G" Ids="F3DekJArRzoPXDWGQZqfoM,FcDJ5HIIARROslh2omATEF" IsHidden="true" />
               <Node Bounds="405,2380,51,19" Id="VweSW1agLbVMrPNrsu4UpK">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -6014,7 +6036,7 @@
               <Link Id="T4c326PUrGQL7Moeg20dRL" Ids="KLCMJF8ZxDrMzDg5L9Bhc7,Sl0xznLVavVP1mQn1NqjYi" IsHidden="true" />
               <Link Id="KbWKCljHUEvPF0vVCaMpPr" Ids="MmCHGpbp5t3Lpg75FaJ0Fh,KLCMJF8ZxDrMzDg5L9Bhc7" />
               <Pin Id="Unr4dm9oxWlMj9YPPOAt6R" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6025,19 +6047,19 @@
               </Pin>
               <Pin Id="Jrns9196nMoPuYLkZ8XUZm" Name="Byte Index" Kind="InputPin" />
               <Pin Id="TUi8uTEx9GBMmM2OQCs8qL" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="F3DekJArRzoPXDWGQZqfoM" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Vwyuwa9uMUnNHUJlQcgJVB" Name="Args" Kind="OutputPin" />
               <Pin Id="P95tMp21rSuM8C3C9ZoM4Z" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="Sl0xznLVavVP1mQn1NqjYi" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6049,7 +6071,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="169,2547,367,124" Id="P4fGxubb02OP7ClImTNBm9">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="LwELri5Agh2LwV8qeASEj2">
@@ -6060,7 +6082,7 @@
               <ControlPoint Id="PBj5qe1eHGaNOlimaPfymW" Bounds="183,2654" />
               <Link Id="KXl0ArWQ7cUPf4A4UI3pAb" Ids="PBj5qe1eHGaNOlimaPfymW,TuFT6RVy3wxNAwFSHPbIrv" IsHidden="true" />
               <Node Bounds="181,2599,84,19" Id="Q6mgGxDs6E4MwS2m31WcEr">
-                <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastSymbolSource="VL.IO.OSC.dll">
+                <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastDependency="VL.IO.OSC.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackString" />
                 </p:NodeReference>
@@ -6079,7 +6101,7 @@
               <ControlPoint Id="Q7ULKMe5QOKLe2tgFEkXGJ" Bounds="421,2565" />
               <ControlPoint Id="EYVZyVKu8X8LAasxD5FzEG" Bounds="421,2654" />
               <Node Bounds="419,2598,51,19" Id="QaQSvuuDN2wMyXc2uYhhSH">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -6093,7 +6115,7 @@
               <Link Id="NhK5iOqP0piOYBoT6XgdtC" Ids="Q7ULKMe5QOKLe2tgFEkXGJ,PryrP4YGNWtP0zO6Q36boV" />
               <Link Id="UHgQ8EHzRoCLxhnJ9TbbB4" Ids="VNkOQ3pLSjoLxrSwttXkDT,EYVZyVKu8X8LAasxD5FzEG" />
               <Pin Id="IfAovDqH7W5LEaP6pQAtci" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6104,19 +6126,19 @@
               </Pin>
               <Pin Id="D1UdsVYDR86ORidL5P5Ohp" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Qt5WMZBPeFfMv1LRxSIkfA" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="EcFpTtm5AlTL1LxkjJ2NKu" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="TuFT6RVy3wxNAwFSHPbIrv" Name="Args" Kind="OutputPin" />
               <Pin Id="I2NqnS23pGBP5uXJrSYuH4" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="AXeTmDqHn4VL2SqkhQEt7v" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6128,7 +6150,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="101,291,556,453" Id="EsrWMIk7sRUPF9dNNU4Zn8">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="P3uEV2w7HKTNriyKf2jRC0" IsGeneric="true">
@@ -6141,7 +6163,7 @@
               <ControlPoint Id="VGUuqBKsE4NP7DdnJEkGI7" Bounds="328,711" />
               <Link Id="F6mbkvQg5DLLLAQfB2m1c5" Ids="VGUuqBKsE4NP7DdnJEkGI7,Cn9LOu8RzpTPfi8Wyil0Y5" IsHidden="true" />
               <Node Bounds="197,394,307,300" Id="JYfUnltWpFuNEjqFFM5zf2">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -6163,7 +6185,7 @@
                   <Patch Id="Ncl7G3Mte7PPnvFKh68THw" Name="Dispose" ManuallySortedPins="true" />
                   <ControlPoint Id="Ps6gd518G8YPc65Ubep1N0" Bounds="352,668" />
                   <Node Bounds="348,474,31,19" Id="OHzxlKRXg9nPmvJmmhyVjy">
-                    <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="&gt;=" />
                     </p:NodeReference>
@@ -6172,7 +6194,7 @@
                     <Pin Id="VbemOCfaMwdLdM74arQE9Y" Name="Result" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="250,433,70,19" Id="AO5eKZM1VzjNvX086bwuU2">
-                    <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                    <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                     </p:NodeReference>
@@ -6185,7 +6207,7 @@
                     <Pin Id="UnYRDgEKsBwP1woMM4SJej" Name="Next Byte Index" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="335,544,157,103" Id="LrIlVmFdT4GMvtq881S2FS">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="If" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -6197,7 +6219,7 @@
                       <Patch Id="F9l8aBomkIXNJaUB0w2FTV" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="VIssxGh6hlKQcbU817nBE0" Name="Then" ManuallySortedPins="true" />
                       <Node Bounds="349,606,27,19" Id="Gtx1uE826wuONGA3H4DPjv">
-                        <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="!=" />
                         </p:NodeReference>
@@ -6206,7 +6228,7 @@
                         <Pin Id="C3b78H378VGN3TrbsQQCzS" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="347,567,58,26" Id="BVhUNK363gSOOfTdIzR5R1">
-                        <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="StringType" Name="String" />
                           <Choice Kind="OperationCallFlag" Name="GetChars" />
@@ -6216,7 +6238,7 @@
                         <Pin Id="UGfB08DTjt9N6wCseMcX4V" Name="Chars" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="422,568,58,26" Id="TcgYMDPGoZ7QD1AXqSzUG4">
-                        <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                        <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="StringType" Name="String" />
                           <Choice Kind="OperationCallFlag" Name="GetChars" />
@@ -6228,7 +6250,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="334,512,37,19" Id="CC6BiG1fmlpMHIgQCoAY7s">
-                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="NOT" />
                     </p:NodeReference>
@@ -6238,7 +6260,7 @@
                 </Patch>
               </Node>
               <Pad Id="SznXzIUlsBDLIjgfTe71jX" Comment="While" Bounds="117,343,35,15" ShowValueBox="true" isIOBox="true" Value="9999">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
@@ -6253,7 +6275,7 @@
               <Link Id="AJGcrqQeE0WNTQ2OrjCVzS" Ids="IvmR3nNnqCxPcNt50V2QeI,VGUuqBKsE4NP7DdnJEkGI7" />
               <Link Id="BvfPUwL3qdaLkvjoTAmTN3" Ids="Ps6gd518G8YPc65Ubep1N0,ENCwAZMwFZIObLXHjpQDiv" IsHidden="true" />
               <Node Bounds="392,350,44,26" Id="OH7kdkgXDE6PirqTnhaSo9">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Count" />
                   <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -6292,7 +6314,7 @@
               <Link Id="NTdDDYOaHxDQVVlErCREUz" Ids="UGfB08DTjt9N6wCseMcX4V,R2ei0XItM5PPjjwXKL7wIZ" />
               <Link Id="TKYVQSuzDsOQcl0Kkbtm9F" Ids="C3b78H378VGN3TrbsQQCzS,BvcxOWSNAqeNoH4VgaGQCW" />
               <Pad Id="Eqhx5VHqMcLMGvOvcLOTO6" Bounds="500,568,138,84" ShowValueBox="true" isIOBox="true" Value="&lt; break if the next typetag is different, ie is not part of the same spread anymore">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
                 <p:ValueBoxSettings>
@@ -6301,7 +6323,7 @@
                 </p:ValueBoxSettings>
               </Pad>
               <Pin Id="RdlqYDMH1ugN1PbRtrvR63" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6311,13 +6333,13 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QSGKwD8gnaBLDCPcPbUvN1" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="FZVPAx0AoY1NVididCZAPN" Name="Byte Index" Kind="InputPin" />
               <Pin Id="DXnriZWD2BDOjUh24AotRW" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6332,7 +6354,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="127,851,330,183" Id="Lq29LgY0IQpPaDwUouzc1H">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="VyeZcXCEotiPmFWGEmA5Us" IsGeneric="true">
@@ -6345,7 +6367,7 @@
               <ControlPoint Id="HRrXrTv7J2QL3oYZFGZ0lS" Bounds="362,987" />
               <Link Id="H4rAzKddNfsLWCjNr3LoIU" Ids="HRrXrTv7J2QL3oYZFGZ0lS,SbnV2gdIF8gQBN6Plrx8wQ" IsHidden="true" />
               <Node Bounds="139,966,70,26" Id="T9gAGeuliupNanqFAOpfwr">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (2 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (2 Items)" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
@@ -6355,7 +6377,7 @@
                 <Pin Id="E6h2NpjkIk8PZ6pgT4aCqg" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="139,894,70,19" Id="HjM83ltgHE8N5O83E0zFV7">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -6368,7 +6390,7 @@
                 <Pin Id="J77QhTqX7zzNIYmupT6OF3" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="203,934,70,19" Id="UFH6NMTBORFLg2vboIo79f">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -6400,7 +6422,7 @@
               <Link Id="PVCYsHNnH7lQIpIwRvz9pC" Ids="RMStW2eSIS1PviheJdYJps,KJzlkNOZEmHPfu1A00zlgj" />
               <Link Id="UoidCm1nG5HLO9ZdOf7x1H" Ids="Beaj3zqr8yMQUJ4cAL6Ip4,VVx4b4P5aUjLqCgpCkyLMG" />
               <Pin Id="IMwipLZj7c0OTivJ6y62qB" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6410,19 +6432,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Re48s7aIDd7QYRHdS65CjC" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D4CgLUKf1z5MYllmDfJJ2Q" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Kvcu67pnM8XLzobAwjJfnx" Name="Byte Index" Kind="InputPin" />
               <Pin Id="TCfjGeAwj1fO3N1Cm2nb1h" Name="Args" Kind="OutputPin" />
               <Pin Id="Q2B4Yj1vh2zPA2Wwi4epfg" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6435,7 +6457,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="156,1852,375,203" Id="DdvV6R51yC7MNgN3bDzh1E">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="GBTeFWaxgAuLtSYH0TZQBo">
@@ -6446,7 +6468,7 @@
               <ControlPoint Id="QE8yFcOfKGBL007Aa6fmiR" Bounds="171,2036" />
               <Link Id="IfEPCJFnPU7Pa7vEA1qNiO" Ids="QE8yFcOfKGBL007Aa6fmiR,NSVfyGIujm0NEDBXPxQuWd" IsHidden="true" />
               <Node Bounds="168,1904,84,19" Id="KAXhrlIgGxsOz19up1mxIX">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -6460,7 +6482,7 @@
               <Link Id="Jk0yslARAvQNDZxOYgceTI" Ids="PSkHf3q29tlOaCMG3SPXdc,Pw3I1INmIJaLbeQh5DCX5L" IsHidden="true" />
               <Link Id="PU4BpbuoVUZONWiWfPEZ0m" Ids="GPLG1KymnwZNjagKr6dHJR,EYT17XKQuUzPJ7oYYYxIBN" />
               <Node Bounds="170,1975,46,19" Id="J38Xt2fRZvWQHqouQsgYtI">
-                <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
@@ -6471,7 +6493,7 @@
               </Node>
               <Link Id="QKil9Sfd4s7OeQyeJUddom" Ids="BgNx5UfFvSgOELAiSkfZBQ,Hu9P2ILay0AMbEROaNfZd9" />
               <Node Bounds="198,1934,84,19" Id="SeNm1xRGxObPiv3eCPilPQ">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -6487,7 +6509,7 @@
               <Link Id="QiQoEtZxbWbPkO3574zXnU" Ids="SLEZ8lSoSd0OjVvOqxSMcm,QE8yFcOfKGBL007Aa6fmiR" />
               <ControlPoint Id="GrqeoRIkN01MmXL7Cdt4Uo" Bounds="416,1871" />
               <Node Bounds="414,1952,25,19" Id="S3bVA9NlxtSQOwhELuplI4">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -6504,13 +6526,13 @@
               <ControlPoint Id="G34ZyGHSU9NNm8LaZGrF5c" Bounds="336,1871" />
               <Link Id="CbCBOLuyRllMlkPFURb6gI" Ids="Fi8ZvyqZdMZOpO6syaqc66,G34ZyGHSU9NNm8LaZGrF5c" IsHidden="true" />
               <Pad Id="H5yinC5d66pLoPkvlUlvnP" Comment="" Bounds="436,1931,20,15" ShowValueBox="true" isIOBox="true" Value="2">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
               <Link Id="IW5Ow5w8ZHzQSlOxkoPEs5" Ids="H5yinC5d66pLoPkvlUlvnP,Mnj7JsDIDQmQUAG0bHAaf3" />
               <Pin Id="JWJygOqHguAPXGnG3So0KB" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6521,19 +6543,19 @@
               </Pin>
               <Pin Id="DmdFcuzrVNvOrveaE52yUA" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Fi8ZvyqZdMZOpO6syaqc66" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LZSZUfjrYKLLJrMwqCNzlk" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="NSVfyGIujm0NEDBXPxQuWd" Name="Args" Kind="OutputPin" />
               <Pin Id="Pw3I1INmIJaLbeQh5DCX5L" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TOcGiY4tT7gO3vmnYRU7sK" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6545,7 +6567,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="164,2129,381,129" Id="VaXgXcR2kx9NS2H58byXFs">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="DYEzr2hyKVMMV3GdKhRjhW">
@@ -6556,7 +6578,7 @@
               <ControlPoint Id="UwA60UYe0q2N2TrBNIahY8" Bounds="178,2241" />
               <Link Id="HnTBYYqCeTqLi0TxJHZtcR" Ids="UwA60UYe0q2N2TrBNIahY8,M5t57jGw20ZN0a7L7eQSD7" IsHidden="true" />
               <Node Bounds="176,2181,94,19" Id="K9p6dyEeXbWNHZLSFz5pEA">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackInteger32" />
                 </p:NodeReference>
@@ -6579,7 +6601,7 @@
               <Link Id="FxadJFTWoUyL9WIZxkRmrv" Ids="NG0wJVgxT1TMplqOCck0wV,IdPyRPypzZuO6gvlEERJ9B" IsHidden="true" />
               <Link Id="Bdccfu0PGajOEjTfytmuTk" Ids="VRpdwlZAIPaM1Xv5FY9zlk,Po2BMZQxeIPLoENHG2Mhez" />
               <Node Bounds="427,2183,51,19" Id="DxR33tIOv08ObAUcaIpFTK">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -6589,7 +6611,7 @@
               </Node>
               <Link Id="RPSZJpGWLPuMSCG2sWRTAC" Ids="T1ZV6BTsex8M084AhPCbkO,NG0wJVgxT1TMplqOCck0wV" />
               <Pin Id="Aq8BixapqSSMNMxnE2kieJ" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6600,19 +6622,19 @@
               </Pin>
               <Pin Id="PzuEOOFS9wyLJMIrRe2YLF" Name="Byte Index" Kind="InputPin" />
               <Pin Id="AmkT3x9hLAyPpf2z1RUp9N" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="RK1QaKH5PhhNsESqTPOFwi" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="M5t57jGw20ZN0a7L7eQSD7" Name="Args" Kind="OutputPin" />
               <Pin Id="FxM5S4grP7aOIGyb8zyqSB" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="IdPyRPypzZuO6gvlEERJ9B" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6624,7 +6646,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="168,2741,365,124" Id="GBVCO2OyXHrN0QubqPtb9Z">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="TOxOXjq52qLOgq7L8f3ItH">
@@ -6635,7 +6657,7 @@
               <ControlPoint Id="RbMAQlbg3FpO22MiLvEfP8" Bounds="182,2848" />
               <Link Id="RIgT5u4QS1jP2EVOyHcMIu" Ids="RbMAQlbg3FpO22MiLvEfP8,HelZeBiU2tpOzLBPyKU14X" IsHidden="true" />
               <Node Bounds="180,2794,84,19" Id="ScPuSSYIZ3PPwRhXx2BHpw">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackColor" />
                 </p:NodeReference>
@@ -6654,7 +6676,7 @@
               <Link Id="BtAn54lu582QCi6rCb4V2f" Ids="B4LcGwISMsBPIt8IICO8Bi,TvVUjZpgBljPbvaRFD9nN5" IsHidden="true" />
               <ControlPoint Id="F6MmSl40wDQLAYexyYrUi4" Bounds="418,2759" />
               <Node Bounds="416,2787,51,19" Id="SI33iX9pdRQPUk8gZFG8z6">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -6668,7 +6690,7 @@
               <Link Id="IUYuNkY0lMrO3bGKMH2nDQ" Ids="VltU3aY2MPoODO15IcUP36,TPWQ0VrkxXIOcXddKRFi6w" IsHidden="true" />
               <Link Id="Sm1mZMEJFvfMWj8yoZLhE2" Ids="BiKH4rzqXUNLXKOGus40Yl,VltU3aY2MPoODO15IcUP36" />
               <Pin Id="OKlovQj0qaGPzyT245ARkn" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6679,19 +6701,19 @@
               </Pin>
               <Pin Id="SHnUByAteqGOb78lG32Cet" Name="Byte Index" Kind="InputPin" />
               <Pin Id="B4LcGwISMsBPIt8IICO8Bi" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LRLkX4ZE7hwOfxLjvbwGam" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="HelZeBiU2tpOzLBPyKU14X" Name="Args" Kind="OutputPin" />
               <Pin Id="Kgd9qavgysrLU0f0I28sIL" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TPWQ0VrkxXIOcXddKRFi6w" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6703,7 +6725,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="517,837,325,239" Id="B3yu5gc9SDwPCltMbcCg7O">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="Tzu2vz0R3BTMFNAguFV3A6" IsGeneric="true">
@@ -6716,7 +6738,7 @@
               <ControlPoint Id="IjCCTTUiklxM3q6lueq7S6" Bounds="747,1053" />
               <Link Id="PJ10ThvguxlLa5bNCc4R12" Ids="IjCCTTUiklxM3q6lueq7S6,PGLaYtlVnfgNrewuZxnE92" IsHidden="true" />
               <Node Bounds="529,1008,70,26" Id="H0Dwum5U0LeMjmAeGh4gxe">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (3 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (3 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (3 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
@@ -6727,7 +6749,7 @@
                 <Pin Id="JBW0vgrGKo1MMshgWm4fpH" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="529,883,70,19" Id="VdGtK5VbevaQPoA0GGDhE1">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -6740,7 +6762,7 @@
                 <Pin Id="S0WQdIN5SC7L5CmH17Bvw0" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="563,934,70,19" Id="D3kfV4wBIvULGejCxras6B">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -6760,7 +6782,7 @@
               <Link Id="KXFH26zEF3SL4dHFmH2xSF" Ids="S0WQdIN5SC7L5CmH17Bvw0,Fn8bI5h2bljPxPCdqDwIFd" />
               <Link Id="DCp4DPXnKpYLqnF31D5C2r" Ids="JBW0vgrGKo1MMshgWm4fpH,CwgJr4kUj1DMHCuI6wkns1" />
               <Node Bounds="596,974,70,19" Id="S1XiNw1lGPmOU9fgXNe0ae">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -6790,7 +6812,7 @@
               <Link Id="S0rvCf3e6oUMWKp6uIEJ1l" Ids="BfB9lWjjeTaOrrtTbs2B1r,NuAP89wtmduQbDxPWc2QP5" IsHidden="true" />
               <Link Id="NsF5n8jxuEqMWavmyctVor" Ids="NuAP89wtmduQbDxPWc2QP5,DbIyS5Rp8qCMDCEF7b89m8" />
               <Pin Id="En1QwZKhrEpMIrLTeksw0e" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6800,19 +6822,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Kfjz9J6E5ymOt1tdKJhlzB" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BfB9lWjjeTaOrrtTbs2B1r" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="UcJiKwE5b9bNi1UGruzrOO" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Smdrc0ZL0JZLIkqE7OuNUX" Name="Args" Kind="OutputPin" />
               <Pin Id="DGzVKJJSogELI8ivq7Qf1W" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6825,7 +6847,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="601,2130,373,128" Id="CR2bbol3IR5LeNiCU7uKPA">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="KiUINEm4arVNxRIdyfFOOM">
@@ -6836,7 +6858,7 @@
               <ControlPoint Id="EA2qEMGVFD9LHwRbwYjLYk" Bounds="615,2241" />
               <Link Id="NJHUABplS0eQJhkV4NlrqN" Ids="EA2qEMGVFD9LHwRbwYjLYk,QQ2mBQMASMZMvKoW6zIFWk" IsHidden="true" />
               <Node Bounds="613,2182,94,19" Id="IYNIXX0SfA3O5J2z4Rmxm3">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackInteger64" />
                 </p:NodeReference>
@@ -6855,7 +6877,7 @@
               <ControlPoint Id="CRhymXRK16CMvR1J65rJyO" Bounds="859,2148" />
               <ControlPoint Id="I0YYAQ4XmUMMuGDCJEUVno" Bounds="859,2241" />
               <Node Bounds="857,2186,51,19" Id="PGfVTGA1Eu3QIK3nGqLOZr">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -6869,7 +6891,7 @@
               <Link Id="JscLSbiJ49sMVSsr7xEIhY" Ids="CRhymXRK16CMvR1J65rJyO,QY7U8s8VotjPEPJ8LLCaVn" />
               <Link Id="GZrLc5r0M4VQGa5jJNfS1q" Ids="AITvNmcb2KhPsYg9PuDxNW,I0YYAQ4XmUMMuGDCJEUVno" />
               <Pin Id="NiqulPlXGJHLsINLGWCe4x" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6880,19 +6902,19 @@
               </Pin>
               <Pin Id="BES8pK9mWJfNfr9rUBcDGd" Name="Byte Index" Kind="InputPin" />
               <Pin Id="CZWNr76nJgZL37XqVsZgbk" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Pr60KS1jshaLDDhk1lCL2t" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QQ2mBQMASMZMvKoW6zIFWk" Name="Args" Kind="OutputPin" />
               <Pin Id="HC6J52COzDYQOarOd4qk28" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="NfE04egi8dpOo0Wgk2J4MR" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6904,7 +6926,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="605,2331,362,130" Id="GeD7vb90CVVPienayezONY">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="Eb7yM2PjmO5NIaSCRI53yn">
@@ -6915,7 +6937,7 @@
               <ControlPoint Id="KI8uY6vKyhaQTU4xrsFfSk" Bounds="619,2443" />
               <Link Id="NqlSvSVwAtYOIWlmzOK9hh" Ids="KI8uY6vKyhaQTU4xrsFfSk,GllO6sJAd68N4lCg91ezLk" IsHidden="true" />
               <Node Bounds="617,2383,84,19" Id="M0N5rDjEBzANvVYGvyremk">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat64" />
                 </p:NodeReference>
@@ -6934,7 +6956,7 @@
               <ControlPoint Id="RBtdopV5yvzLgrSqO2RNx1" Bounds="852,2351" />
               <ControlPoint Id="Nb3c1IiiTXUNZ1nTmvubpi" Bounds="852,2444" />
               <Node Bounds="850,2389,51,19" Id="GknuhfiqrF4PZ0l9ECjS0d">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -6948,7 +6970,7 @@
               <Link Id="Hi2wSFaHXjoMC1w5KOYjTU" Ids="RBtdopV5yvzLgrSqO2RNx1,LDn5wHJpJBBLolPfx2eVrs" />
               <Link Id="R5KqHnkqLNtPfxBIs8KFeD" Ids="TjG8WupHLpQOKpNxK58qeE,Nb3c1IiiTXUNZ1nTmvubpi" />
               <Pin Id="F9DKPjWumvAOHuaq51vnqX" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -6959,19 +6981,19 @@
               </Pin>
               <Pin Id="T32euGldqezPWoZb3WiJbh" Name="Byte Index" Kind="InputPin" />
               <Pin Id="SqpH0ejcJEgPQMAJuLttEQ" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="B1KZH35lsHYOwQtxn76kKi" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="GllO6sJAd68N4lCg91ezLk" Name="Args" Kind="OutputPin" />
               <Pin Id="KMET04s46HnPLhFtQBtNFu" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TBcmgZ2QXNMP04Tl43nROv" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -6983,7 +7005,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="611,2541,367,129" Id="FFWQ0hO2jn2PitCn6K1e9v">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="Iz1sxIhZeRoPntlzIjluol">
@@ -6994,7 +7016,7 @@
               <ControlPoint Id="OIFZp0OW0EXO3qrVnOudgW" Bounds="625,2651" />
               <Link Id="PzhaYSUtn6MN55ZA45Rzbj" Ids="OIFZp0OW0EXO3qrVnOudgW,LRBmu7LpamhPa8d8PM4WkM" IsHidden="true" />
               <Node Bounds="623,2593,84,19" Id="OAIhUttZi04PvrSPNbBMrs">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackChar" />
                 </p:NodeReference>
@@ -7013,7 +7035,7 @@
               <ControlPoint Id="LAza4o7DjRFNRh25DZ6dVH" Bounds="863,2559" />
               <ControlPoint Id="VplAgdQJZHVPVeiCPIKrj9" Bounds="863,2651" />
               <Node Bounds="861,2595,51,19" Id="TFrb1AQbVMcMgzAKUExb06">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -7027,7 +7049,7 @@
               <Link Id="GLIvqf3F4MSN06z3FCl1st" Ids="LAza4o7DjRFNRh25DZ6dVH,BG5O0YYRFRhL1twGv2AYaA" />
               <Link Id="V79R9VysUpnO7hbXSW4AQD" Ids="Ua8tv2084GZP2lxsFQrTLD,VplAgdQJZHVPVeiCPIKrj9" />
               <Pin Id="UGU8Ta6UQjJMLpWd3DxN1o" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7038,19 +7060,19 @@
               </Pin>
               <Pin Id="JiFgGj6oeR2N0mwgd9I2XZ" Name="Byte Index" Kind="InputPin" />
               <Pin Id="LHzXugVk6qGNaqm94Sq4a0" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="DMdjKKWmtChMuiNlQt8dAq" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LRBmu7LpamhPa8d8PM4WkM" Name="Args" Kind="OutputPin" />
               <Pin Id="QYcia6hlOozLiD4wmn4MvQ" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="Hm7UM1E5bxpOzWdpUlu037" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7062,7 +7084,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="172,3201,369,128" Id="QqVXnZ4BFGnMK0eGrFkrL0">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="PP4g5vG9H7HPXIEU7sK4s6">
@@ -7073,7 +7095,7 @@
               <ControlPoint Id="LBJnPuxLbbXPQtWXQ0zOtZ" Bounds="186,3312" />
               <Link Id="V2zYwZcg4LaPXJS0ZMA3Du" Ids="LBJnPuxLbbXPQtWXQ0zOtZ,LGB3VxghEbZLalNW42jpfU" IsHidden="true" />
               <Node Bounds="184,3253,84,19" Id="BZ3S0tYHmMfOwHgvqjsdqC">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackBlob" />
                 </p:NodeReference>
@@ -7092,7 +7114,7 @@
               <ControlPoint Id="GxojIbSaXOWOMJVRHkBQO4" Bounds="426,3219" />
               <ControlPoint Id="HTlfFo2t6CpLCXsXSIKmlx" Bounds="426,3312" />
               <Node Bounds="424,3258,51,19" Id="RcLAGTjFNs9NbCYAPt9XXg">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -7106,7 +7128,7 @@
               <Link Id="IrtJcrwMeQyOa76GXXt1lG" Ids="GxojIbSaXOWOMJVRHkBQO4,AUx1kVkCpCXQb7Y2E95ILD" />
               <Link Id="QtN4ZgaGtUNLKyURgbYJlA" Ids="UMyrUSX1akbNWR30IGpWqj,HTlfFo2t6CpLCXsXSIKmlx" />
               <Pin Id="MiDPEbYgAbiPA84ioVapCQ" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7117,19 +7139,19 @@
               </Pin>
               <Pin Id="BVPxLyO50vAPv5aEb7GLDP" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Q87WG8IX6rvNCjyEyYjhiK" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CO582Edutd0PaytWvHUmjo" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LGB3VxghEbZLalNW42jpfU" Name="Args" Kind="OutputPin" />
               <Pin Id="DTEuUoa10jDOzvfz3C0Lxv" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TCe4HPPKA02LNAIi9riNCT" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7141,7 +7163,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="600,1854,384,203" Id="KorNtsJR7lkPIZSuUttyqM">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="CUGsXtomUa0N0ouG9I3AND">
@@ -7152,7 +7174,7 @@
               <ControlPoint Id="RqGoKuXAAt3OGHR0pdnP8K" Bounds="615,2038" />
               <Link Id="PxkN49haL9xLtFIA1MqsKT" Ids="RqGoKuXAAt3OGHR0pdnP8K,Md48noJAKkaPaqF0XLhvwK" IsHidden="true" />
               <Node Bounds="612,1906,84,19" Id="BvinKWdCpTILNKUKvjmm8D">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -7166,7 +7188,7 @@
               <Link Id="IyCV32znX7qLsoTl1iQsCW" Ids="RoubzbCz599QA9ETktdITe,QYEzCBVIQ6GN7rDLa9eIIR" IsHidden="true" />
               <Link Id="A9FqW34MrP9PSkqgVQSnEV" Ids="JUKY9aDDm0DN0b2P9HoPqe,DtqRGolOWQrP85OBSdJKyz" />
               <Node Bounds="614,1997,46,19" Id="UXdQbM8MLvdLuGcd2p8nmz">
-                <p:NodeReference LastCategoryFullName="3D.Vector3" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector3Type" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -7178,7 +7200,7 @@
               </Node>
               <Link Id="TYR2CsfeqK5LP7IudTAEkO" Ids="N8UndrjqT8yNtyZMP0nMkA,PdYRQZAIOH4LLkizebcCYB" />
               <Node Bounds="642,1936,84,19" Id="AzOP7fhXhESN9Tv2p7s6SM">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -7192,7 +7214,7 @@
               <Link Id="A4Ws3FdotkzMMXHDSi3wmO" Ids="AfZ0MtY5JQrOSTJnhpwuP8,MCUZbvTCcN2Pc5zmOmuBtZ" />
               <Link Id="CjTSD7U9TBFQVwlnyqbBoD" Ids="TzKPfHMxLvfNxx3819nGhD,RqGoKuXAAt3OGHR0pdnP8K" />
               <Node Bounds="681,1966,84,19" Id="Fpn1tNypERoPzht12iFdWo">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -7207,7 +7229,7 @@
               <Link Id="I0ostR7wjzRMj32fseSY3o" Ids="JYPFfrFwd6eLWvvbCzSzJq,RoubzbCz599QA9ETktdITe" />
               <ControlPoint Id="L0jGu7ybjiZPoyfGl5kp0x" Bounds="869,1875" />
               <Node Bounds="867,1956,25,19" Id="SPkqQ9pTJgROCZ65OoNEnI">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -7219,7 +7241,7 @@
               <ControlPoint Id="PYXHEYkipxYPDdZvx52PzT" Bounds="869,2040" />
               <ControlPoint Id="SHgsDtmZGONP8bzYXexXMf" Bounds="789,1875" />
               <Pad Id="M1svye3JuAiNIZIkfpItNF" Comment="" Bounds="889,1935,20,15" ShowValueBox="true" isIOBox="true" Value="3">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
@@ -7230,7 +7252,7 @@
               <Link Id="ARcVm7fqar8OQw1678jtHh" Ids="QtjTCElAPBFNgkXaGKfQi7,SHgsDtmZGONP8bzYXexXMf" IsHidden="true" />
               <Link Id="PRe6WtKN5uuNlyBGD9mzJ9" Ids="M1svye3JuAiNIZIkfpItNF,STBzGEZPrUzPoHyhkagzVN" />
               <Pin Id="PRYlXpHG3IjQYcRzXk5AJK" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7241,19 +7263,19 @@
               </Pin>
               <Pin Id="O1VoHBXVj7GLsrBJUhU7HY" Name="Byte Index" Kind="InputPin" />
               <Pin Id="QtjTCElAPBFNgkXaGKfQi7" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Bzha7qGzsFcPMjlmYAQfII" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Md48noJAKkaPaqF0XLhvwK" Name="Args" Kind="OutputPin" />
               <Pin Id="QYEzCBVIQ6GN7rDLa9eIIR" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="HaJHjLpp5JULgHjLHaEXcG" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7265,7 +7287,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="1078,1841,441,247" Id="IWYQoMEQ1qNLvNfYn4SwWE">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="Taib9er7LJXPQ62Ow2oPMr">
@@ -7276,7 +7298,7 @@
               <ControlPoint Id="FTSqCleAu9QN79y8SmzJId" Bounds="1094,2071" />
               <Link Id="T6CStaRATgmQDrk4uh0bUw" Ids="FTSqCleAu9QN79y8SmzJId,JVY5ncDCqwiNdNASUpliKZ" IsHidden="true" />
               <Node Bounds="1090,1893,84,19" Id="Ef2tkD756uxMonkGta2tbp">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -7290,7 +7312,7 @@
               <Link Id="FhTYh8S2OQFLSxoV6bc8pr" Ids="MRG20SRSaTNPs0n5FnLa1F,Hmz3dkpjPmbLmnzKCwGEZx" IsHidden="true" />
               <Link Id="HF8HLceAGOqLAJBxJwInF9" Ids="DfJBWiv20euPhPWeR6EL3r,InfkIipsU12PGcfEMk8tEM" />
               <Node Bounds="1092,2024,65,19" Id="DHa3SPEQYpXMh4DHSkYzW4">
-                <p:NodeReference LastCategoryFullName="3D.Vector4" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="3D.Vector4" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
                   <CategoryReference Kind="Vector4Type" Name="Vector4" NeedsToBeDirectParent="true" />
@@ -7303,7 +7325,7 @@
               </Node>
               <Link Id="LBSmeUg0gzTOsCvcvuLTZT" Ids="BnSTIAIb4FKNL9zh32NrxR,VNrY8h4jJomQHaYZ9wyauz" />
               <Node Bounds="1120,1923,84,19" Id="Ts1PQGpXT3NOUIUAsRRbrG">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -7317,7 +7339,7 @@
               <Link Id="UNsVIjt7i4YNk0smxJs4Ci" Ids="IJcCZqN4HM6OAhLYdQSfLo,LLpTx6KKTZXM5hpHK0u2OR" />
               <Link Id="O8Na8k8P7z8PmK0RufYpDp" Ids="FtLqZZy1KnUNAtoYOEnwIa,FTSqCleAu9QN79y8SmzJId" />
               <Node Bounds="1150,1953,84,19" Id="CeS2FbHrbDqOrzz0pwK1A7">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -7327,7 +7349,7 @@
                 <Pin Id="GeSBAEGHEtkQJS5PVtUgDs" Name="Next Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1180,1983,84,19" Id="EVxwb9H4XyFM4E3Up0Eu4s">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="UnpackFloat32" />
                 </p:NodeReference>
@@ -7345,7 +7367,7 @@
               <Link Id="UhOj3Or0dRnNCo2cWcs4fg" Ids="HkZHq4Gx00CMJhDk8VfiEF,MRG20SRSaTNPs0n5FnLa1F" />
               <ControlPoint Id="Ntgzf1gOQHhQJhFcsqLBaS" Bounds="1403,1861" />
               <Node Bounds="1401,1942,25,19" Id="HzlTZCBuOcqO3ZIYgLSIM0">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -7357,7 +7379,7 @@
               <ControlPoint Id="HelHttsKK8EPWBWfM7fLaa" Bounds="1404,2071" />
               <ControlPoint Id="JbXwmCrL6kSMsaTkmLiB4b" Bounds="1323,1861" />
               <Pad Id="Dft8M2kO6JcLuJ6PFZ8lQi" Comment="" Bounds="1423,1921,20,15" ShowValueBox="true" isIOBox="true" Value="4">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pad>
@@ -7368,7 +7390,7 @@
               <Link Id="OjmJoCmPkncLPOFI5incFp" Ids="BGDMs7jurFHLAk8vTef6Np,JbXwmCrL6kSMsaTkmLiB4b" IsHidden="true" />
               <Link Id="KH4IaOb9MjXO2X9xbFPMhB" Ids="Dft8M2kO6JcLuJ6PFZ8lQi,AS6JCvJ3OlcOuPBsVy4wOD" />
               <Pin Id="OwrkCTULJIsO2W3cMicbmj" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7379,19 +7401,19 @@
               </Pin>
               <Pin Id="P8ca1KaHzx2P65yCPZdYPu" Name="Byte Index" Kind="InputPin" />
               <Pin Id="BGDMs7jurFHLAk8vTef6Np" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LsJ70OuipIeMcqu549n42r" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="JVY5ncDCqwiNdNASUpliKZ" Name="Args" Kind="OutputPin" />
               <Pin Id="Hmz3dkpjPmbLmnzKCwGEZx" Name="Next Byte Index" Kind="OutputPin" Bounds="839,1240" />
               <Pin Id="TFlRxECxzfiL9YMJUdflrZ" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7403,7 +7425,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="171,2947,373,194" Id="RCq4RER4knvPCsMIaczM8S">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="O5f49QSCcOrLeHHVtnYQwN">
@@ -7423,7 +7445,7 @@
               <ControlPoint Id="Lg87Sa4IxGTNJEt9DmVBcw" Bounds="320,3124" />
               <Link Id="LrYe4HDIsa2PxSTADQWeKp" Ids="Lg87Sa4IxGTNJEt9DmVBcw,IyENwMgQlyaNhtWys8xjsE" IsHidden="true" />
               <Node Bounds="239,2993,58,26" Id="QvQZe7ZVGn7PBomqoDxJKF">
-                <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetChars" />
                   <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
@@ -7435,7 +7457,7 @@
               <Link Id="AKvFay5PUtyPceiyOBLHhE" Ids="Knu7ucgI5hsO3M6ejjKmau,DHu6Jy1lIYuQDjl7XIzrwU" />
               <Link Id="Mnu1Qg3xaGBMwdziXUeEe5" Ids="NUmN2u4bXESPKJ3eoQ0B1u,OXAIN26skxhL6qj7lDYDe0" />
               <Node Bounds="239,3075,25,19" Id="A7gp6MSBO3gPV19rawAVjP">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="=" />
                 </p:NodeReference>
@@ -7445,14 +7467,14 @@
               </Node>
               <Link Id="CkoBzLmbuyHNwwmDwExWVr" Ids="VCKQ1Ukox0pLJOk08dG8SS,MSbaiwqyN73M4DJ3zcMpc0" />
               <Pad Id="DkIsX1QbYnoMnc8DYlWeds" Comment="" Bounds="266,3048,20,15" ShowValueBox="true" isIOBox="true" Value="T">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Char" />
                 </p:TypeAnnotation>
               </Pad>
               <Link Id="Bl36aAXGmxMP2DtamyM4VM" Ids="DkIsX1QbYnoMnc8DYlWeds,O7AHYNIton2O95lSpR7P1u" />
               <Link Id="JLacANpG6wHNcsjNpOHpZV" Ids="Hy8dnyBGB3PLbTOydORGrf,D4iwDjd87dDPCR32p3mI8w" />
               <Node Bounds="318,3031,51,19" Id="RxFmJlYnaxgOUyuRzt5lv2">
-                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Integer32" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Inc" />
                   <CategoryReference Kind="Int32Type" Name="Integer32" NeedsToBeDirectParent="true" />
@@ -7463,7 +7485,7 @@
               <Link Id="PPpyuQlopxuOy4DTXwUDfi" Ids="NUmN2u4bXESPKJ3eoQ0B1u,KfH7DW9ztsxMmjtCiQu4nw" />
               <Link Id="LaZcKt0W398M3rGJsfU4ZD" Ids="TIhvj61slsYLMJKPCfBgBb,Lg87Sa4IxGTNJEt9DmVBcw" />
               <Pin Id="CB2HIdjqmcoMvIOwDRHimd" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7473,23 +7495,23 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D6O7NYI93QuL1t4Rga1oYV" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="FrOED3gz16YO8c93FZSJhh" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PfnmiNJRcUWO5ft9H3Itua" Name="Byte Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="G5wIs5B7FAaP7Wd9m4iMFy" Name="Args" Kind="OutputPin" />
               <Pin Id="IyENwMgQlyaNhtWys8xjsE" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7502,7 +7524,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="880,834,325,299" Id="Jiqm5MGl3SXMYIbXleWlgq">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="KlAiCQophMcNcGwUbIzfT4" IsGeneric="true">
@@ -7515,7 +7537,7 @@
               <ControlPoint Id="THMR8uqTRRWOxk10hpoZOC" Bounds="1110,1110" />
               <Link Id="EvyTSway6aAMPqTndq4iVk" Ids="THMR8uqTRRWOxk10hpoZOC,AjGaDOmNSIVPDnzs7cqp76" IsHidden="true" />
               <Node Bounds="892,1065,70,26" Id="SYJFQSyKvGGM6dd083utGj">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (4 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (4 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (4 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
@@ -7527,7 +7549,7 @@
                 <Pin Id="IbSlyjhtuiRN6Y1glBFQIA" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="892,880,70,19" Id="Hn3lbW7pUdJQSVXUGbskwH">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7540,7 +7562,7 @@
                 <Pin Id="QWBrpKrSSaOQd4lIcIY5cF" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="926,931,70,19" Id="MTQJzCpGky1OlzoMOEHIwe">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7560,7 +7582,7 @@
               <Link Id="RZVUD3zgDhmQBO5bbO3GHH" Ids="QWBrpKrSSaOQd4lIcIY5cF,GstJJSKgpKXNbrW737YvR9" />
               <Link Id="E7DuAH3ZlHyLNio35Fu4mn" Ids="IbSlyjhtuiRN6Y1glBFQIA,RTbClsWEREKQZ2UgI47D9X" />
               <Node Bounds="959,971,70,19" Id="Fk7BaOjrw7gNiaRO4m83gw">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7588,7 +7610,7 @@
               <Link Id="TnfaTWSg7iCNCcVBfbmPGC" Ids="BClgTyCOAlnL2pZZgrloNy,FAk1NcB1PWJMrKJGC3qazR" IsHidden="true" />
               <Link Id="PswIeJMLjcwLFnOdgw6uvR" Ids="FAk1NcB1PWJMrKJGC3qazR,CddTUdA4FhcNqsBEeOR8xY" />
               <Node Bounds="986,1016,70,19" Id="MvFCyWQFHbONsZFJWf7K3u">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7608,7 +7630,7 @@
               <Link Id="QgGtEWQDxszO1rbKgl6l8k" Ids="S41x5liVKnQNxAUldDSqf9,MXVnWR9FGsFOvNcz81KUfG" />
               <Link Id="Pky1AG9UcULMWGi8nXK0hD" Ids="LH08qmBIoQ9MbSDMtvKZTQ,FNgGXOC70NQNqdDmpeYUiT" />
               <Pin Id="ELfqNRuFZUvL9SeQyYz90L" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7618,19 +7640,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="TlZNfIgFTo1PUyHaL1AFJ1" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BClgTyCOAlnL2pZZgrloNy" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AN1CFVQUB22O0vjiyIUNQD" Name="Byte Index" Kind="InputPin" />
               <Pin Id="OZeuXAeo8QQObAey5Tpohe" Name="Args" Kind="OutputPin" />
               <Pin Id="IepNpDxlLYCNjOXwQtadgq" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7643,7 +7665,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="1293,833,328,338" Id="L6RfbyL4Ll3L8UegaIaMwk">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="EgWCUlDBfyrNflhkMVhDGW" IsGeneric="true">
@@ -7656,7 +7678,7 @@
               <ControlPoint Id="EoNNm6X9VjtMLp2alw41R7" Bounds="1526,1148" />
               <Link Id="UUy494qoKWvQFkNG5bkJzq" Ids="EoNNm6X9VjtMLp2alw41R7,S66DH7ZUmw7LAkEOIjtQ4K" IsHidden="true" />
               <Node Bounds="1308,1103,85,26" Id="DfUG6MGaZu0NeheFj07QFv">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (5 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (5 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (5 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
@@ -7669,7 +7691,7 @@
                 <Pin Id="SCe43KIMsg5MzLCD5zlwsW" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="1305,879,70,19" Id="EDr24El9FyxM9voMmabJ4g">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7682,7 +7704,7 @@
                 <Pin Id="KnYvos6VCuoOHkEg46yKWu" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1339,930,70,19" Id="Ksa1a2AXay8QWeNzzPa5Y8">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7702,7 +7724,7 @@
               <Link Id="F5c4DsIes9GQLlTTOh7IG6" Ids="KnYvos6VCuoOHkEg46yKWu,L4MvCIP3bfgL2u3FXchZUA" />
               <Link Id="UKXlmk2dWtKMJaT8ZVnTm6" Ids="SCe43KIMsg5MzLCD5zlwsW,IB3hCDKrqHIM0XJxv4uFQr" />
               <Node Bounds="1375,971,70,19" Id="To5N712TV8HPdz0JtA8MzQ">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7731,7 +7753,7 @@
               <Link Id="HbiWWnQLiKFLk2uPOH1AuK" Ids="ObjRKypXQisODNS0bpvmh3,SaFVID3kmNVPleaFzzfyZJ" IsHidden="true" />
               <Link Id="NUnc7GihKc7LpLipp2h7c3" Ids="SaFVID3kmNVPleaFzzfyZJ,J4ZNN6hqOkaNElGbc0jQ5L" />
               <Node Bounds="1411,1012,70,19" Id="Ass8NsmY3UsLgpAZql0aWB">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7744,7 +7766,7 @@
                 <Pin Id="IlL1YHB0qjaLbHYamgiXvs" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1428,1058,70,19" Id="I6GyoJLs8yNNHjYtf8x4NO">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7768,7 +7790,7 @@
               <Link Id="Fb8cNljM95ZO4NKv7ST1d5" Ids="Laal3b6T8F0MLqvJR0IJS7,ELQvxdL0TLfOiGMQBAAY7y" />
               <Link Id="MjnGgpJHez2LzGafFzHy3o" Ids="PLorpxjekDaLNBNyXeAwC0,QpkloZQBrNjLT95ORmNtVc" />
               <Pin Id="CuPdl4PAh2GQcwGf7Lt39p" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7778,19 +7800,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="D8DKPPPBYAbOnzxjsvAEZT" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="ObjRKypXQisODNS0bpvmh3" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="I9bppO47UFSLbEj5qwqBvZ" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Suv31t2GfGCOX2Bqlq94ka" Name="Args" Kind="OutputPin" />
               <Pin Id="FsK0tecIhTsNyECMhFXTHb" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7803,7 +7825,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="1686,829,405,350" Id="EoNz9QHxFbDNrmESOeFwkp">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="IpKLMABEhaHNB4mO9pMzi1" IsGeneric="true">
@@ -7816,7 +7838,7 @@
               <ControlPoint Id="KSpvJOXGIkqP6UoqPAk1OI" Bounds="1996,1157" />
               <Link Id="PXlEWxIaYHhPne7YNWLweU" Ids="KSpvJOXGIkqP6UoqPAk1OI,GSFIs3YSN98OPBYIMywdi6" IsHidden="true" />
               <Node Bounds="1703,1111,105,26" Id="C4u73AWyOMaPOBzZ6LpQoh">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (6 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (6 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (6 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
@@ -7830,7 +7852,7 @@
                 <Pin Id="JxgFW5GqoXgMfpM7RSTrnZ" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="1698,875,70,19" Id="SEaj4x8CcT0PUTj0qX7eI5">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7843,7 +7865,7 @@
                 <Pin Id="VF2OYa31KOvNDnVfK0VuG3" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1732,926,70,19" Id="CHYKaMB4f73MrEm2Nv0qVW">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7863,7 +7885,7 @@
               <Link Id="TEDIhvlNbjaLVSXijEL1sf" Ids="VF2OYa31KOvNDnVfK0VuG3,Uwy42erEIHnOL9N5ZttzfC" />
               <Link Id="CTGLcd8NWwZMFQKZjlyk38" Ids="JxgFW5GqoXgMfpM7RSTrnZ,ENIo9nWFqdGPySlDi0LjSC" />
               <Node Bounds="1765,966,70,19" Id="QMz0GuYG37KNn4qOaRgaYY">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7891,7 +7913,7 @@
               <Link Id="Op97cmKCBk5LFdhktZAck5" Ids="AABhZwTjUdUPyL9X36cZ4k,CCkfQyNgw3fO4uKUjVNhvQ" IsHidden="true" />
               <Link Id="CtE2Gf7po8XNhQ6WeQaWnk" Ids="CCkfQyNgw3fO4uKUjVNhvQ,AkMDIKWmsNFN7MU5Zy3y7S" />
               <Node Bounds="1780,997,70,19" Id="FFOTUYSAvcgQSh7M6VtJiv">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7904,7 +7926,7 @@
                 <Pin Id="GUALSD3hjXeN2UA4Xn8AdA" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1816,1038,70,19" Id="PitXLwvN7ndPOC6XibyKbE">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7917,7 +7939,7 @@
                 <Pin Id="Jsac3fOSEthLujA1PCoeKV" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1834,1078,70,19" Id="EfCjI7Yj8LmNZtpn4DQnI9">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -7947,7 +7969,7 @@
               <Link Id="ReRnFmikCujPiqy6RGPmBK" Ids="DznHOJtshewQWxL541rM89,JncUhZyNVAXOtfzbSomzNB" />
               <Link Id="BBtaGbS9o3ALVY10YuDYgB" Ids="Spt3BmsOTjvMhnAHMWkvR1,KSpvJOXGIkqP6UoqPAk1OI" />
               <Pin Id="NHANpUjTAF9LMoWNCh0PDx" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -7957,19 +7979,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QOYyPMiQy8VNuiVTNx57nj" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AABhZwTjUdUPyL9X36cZ4k" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="IL4Xnrf6RhALM6FBnnvo1f" Name="Byte Index" Kind="InputPin" />
               <Pin Id="F4b7iJuBQJmLIY8Xepywmz" Name="Args" Kind="OutputPin" />
               <Pin Id="R7yQZ9gjXaZOXqNe4w0H5N" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -7982,7 +8004,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="2147,836,378,392" Id="PHoMx4xTwDaPCmy09GbOmr">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="ISjDZd044DQPW2OtnAwcKp" IsGeneric="true">
@@ -7995,7 +8017,7 @@
               <ControlPoint Id="NiMpdYE3oWGMeULcCtcoIB" Bounds="2430,1200" />
               <Link Id="S2DROOYb6vPL8M1jTzVn05" Ids="NiMpdYE3oWGMeULcCtcoIB,C33jWOuIJRfNqLd4XHZD0R" IsHidden="true" />
               <Node Bounds="2162,1160,125,26" Id="POgrs0jxO7gQMTgcsc83jj">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (7 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (7 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (7 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
@@ -8010,7 +8032,7 @@
                 <Pin Id="GbEQxw1y6JqLJHMZv6zIIj" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="2159,882,70,19" Id="DPGEAfyXpRDNiMe7dWnRjZ">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8023,7 +8045,7 @@
                 <Pin Id="NsHv9iRiBkIOJfHDEfbqyU" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2193,933,70,19" Id="HUbk9hyw3foOcy01ZqH8O0">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8043,7 +8065,7 @@
               <Link Id="CzYVk3g0kHFPWArl4F3OHy" Ids="NsHv9iRiBkIOJfHDEfbqyU,OsFApYY2FyKLTY7eLljWwt" />
               <Link Id="AGOlavIrgGGNJSsd3GrFQR" Ids="GbEQxw1y6JqLJHMZv6zIIj,LXeBdNymxvXLmkaFT64dYQ" />
               <Node Bounds="2226,973,70,19" Id="TrcZBZQSKdDLTAlFndY2Bg">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8071,7 +8093,7 @@
               <Link Id="UywK8S7hJkJLxv17p4VnxW" Ids="EmMFWVnToezLbyeF1Jdb6O,R5V1RfUpdMVPIpVAk7Z58s" IsHidden="true" />
               <Link Id="OOw0w41vahEOeayMvON5x7" Ids="R5V1RfUpdMVPIpVAk7Z58s,HoFS6lGrCNrPsjDsmYZMEx" />
               <Node Bounds="2245,1009,70,19" Id="C0l7nk4QWdiO2gSHDcmNn2">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8084,7 +8106,7 @@
                 <Pin Id="VVMVEydObuSPTPr5CjPIiT" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2260,1040,70,19" Id="CDtNlFSpJRLMc3q1hd11nT">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8097,7 +8119,7 @@
                 <Pin Id="Cfv6HZtf0YzLD7T6RjSxIW" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2296,1081,70,19" Id="TpTCD0zMl0KPwctIs1TpS2">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8110,7 +8132,7 @@
                 <Pin Id="BlyGNkqF6VOOAH6DmG9FMI" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2314,1121,70,19" Id="EMU4AwAh5STOc7u1IAUhfY">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8145,7 +8167,7 @@
               <Link Id="HpfhY7uShR0PL5fNPcrrmc" Ids="SwAr7Jx090sOOjFF0oGBsC,TLuxc3RoPGjP4hovS8nAKH" />
               <Link Id="V6ySTnQeyfQOPoql9Hpqva" Ids="KzWXfyltWEIMhypC6pwOuG,KEIjvD8YOJALvQQWz1t6xC" />
               <Pin Id="VF4U1SuY0FoL8aouWemnXV" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8155,19 +8177,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="P9w0DGOLHCrPEmE3TOzUq6" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="EmMFWVnToezLbyeF1Jdb6O" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="UUnpZc7KSmkOVqw5d0wgIU" Name="Byte Index" Kind="InputPin" />
               <Pin Id="No0YxEfpTGePIfPPCaZf1h" Name="Args" Kind="OutputPin" />
               <Pin Id="UGg21ajcYS0Nx81RTkW0CN" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8180,7 +8202,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="2606,834,418,465" Id="JYZXiAUnUYaLIwe2g2aD8a">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="TmbgdhW8uQKOxHhkROFh5B" IsGeneric="true">
@@ -8193,7 +8215,7 @@
               <ControlPoint Id="LbyelF0tWB9ORq765jaAHI" Bounds="2929,1280" />
               <Link Id="UFV2Pjc2emzO9Yk9VemyGC" Ids="LbyelF0tWB9ORq765jaAHI,DalQeFyAbs7NE1kPuetxsv" IsHidden="true" />
               <Node Bounds="2627,1231,145,26" Id="Rva363tJIrSMpfq7lOQU2P">
-                <p:NodeReference LastCategoryFullName="Primitive.Tuple (8 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Tuple (8 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Tuple (8 Items)" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Tuple (Create)" />
@@ -8209,7 +8231,7 @@
                 <Pin Id="SJPTuKJ9WnZMkHVCQ8Fj3H" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="2618,880,70,19" Id="UN3kYSg3e41O5rkg1Dn2C5">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8222,7 +8244,7 @@
                 <Pin Id="MvcjFmh60A5NKOnQWb4480" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2649,920,70,19" Id="MpElXqcQ1RTMvwPJ6hsYHZ">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8242,7 +8264,7 @@
               <Link Id="EshwVAqQazqOvLVA5sXrPR" Ids="MvcjFmh60A5NKOnQWb4480,EgUzl6BHV4IMOWnzbKx5ON" />
               <Link Id="QCRny00ezTXOzAaHtWgIEq" Ids="SJPTuKJ9WnZMkHVCQ8Fj3H,GTT8uhnWe0VOox9udke9U5" />
               <Node Bounds="2682,960,70,19" Id="TRzdd5sKSDyMGU0qTrZxqN">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8270,7 +8292,7 @@
               <Link Id="QBdhq35iZiANCkohrjCqOS" Ids="JXMP1H3TrciNC2OQPpv6OT,Gzy5AEUVPOSPLC9i6grGp4" IsHidden="true" />
               <Link Id="LF9AghdEr18L1oD5U4bWoi" Ids="Gzy5AEUVPOSPLC9i6grGp4,KRbaua5hXp2PIyEVRWoWYy" />
               <Node Bounds="2693,1004,70,19" Id="LwkuFNoka5PMZPyO0nd25h">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8283,7 +8305,7 @@
                 <Pin Id="VknXICwlNpRPQkWC1yBuTk" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2712,1040,70,19" Id="NFQDfKTq2nYMqq1NbVGq8y">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8296,7 +8318,7 @@
                 <Pin Id="Fulam5HoECkQTO4hgSGEDv" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2727,1071,70,19" Id="RAz7MvXmQI3OGoOWyBEBt2">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8309,7 +8331,7 @@
                 <Pin Id="PiVjCstxASiNv9Phq3kJV2" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2763,1112,70,19" Id="OMssQJ2vwwmQUNUwilafEU">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8322,7 +8344,7 @@
                 <Pin Id="PvRMuxqhIl9N0WlzBBIbb9" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2781,1152,70,19" Id="GUGweDrdoTqQcjTOggQUp5">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8362,7 +8384,7 @@
               <Link Id="AMERr0nzzxLPClxQlQnMBb" Ids="E15BMtGmXUCPCeqTrvuCUq,OyaLZSdQvkGO3OvYabYjud" />
               <Link Id="NQVh74rndElMkFFsblEey8" Ids="PyhZKOdYXKxMCA5THUJZAU,LbyelF0tWB9ORq765jaAHI" />
               <Pin Id="Iam4sUI2YrpP54kxfNPzqg" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8372,19 +8394,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AgfcdrwO85fOvxLIt24yVH" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="JXMP1H3TrciNC2OQPpv6OT" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QXEvXG5Yu62LQZcSCiS0BP" Name="Byte Index" Kind="InputPin" />
               <Pin Id="QVMCu3IkxStQc0458sZqGI" Name="Args" Kind="OutputPin" />
               <Pin Id="LKO1YJF8ssbMg2NcYPVBQa" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8397,7 +8419,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="134,1371,330,183" Id="NLRghE3NB3mOgheKc8kmV0">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="Jd8HHXApuKTLK1HcRR3bwI" IsGeneric="true">
@@ -8410,7 +8432,7 @@
               <ControlPoint Id="KznynCYGrT4QIzxlOqTOS5" Bounds="369,1507" />
               <Link Id="FzOnPj2MdcqOnehDcmXfYF" Ids="KznynCYGrT4QIzxlOqTOS5,HwKSti8HkdqNv0WUcfxRHx" IsHidden="true" />
               <Node Bounds="146,1486,90,26" Id="Ss8eeiZBelOLfXbZ7eDbuv">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (2 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (2 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -8420,7 +8442,7 @@
                 <Pin Id="VTk4H1zJqTAN2NCq5oNkAv" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="146,1414,70,19" Id="LrfNY4qyMCNMYVXtYFXFQX">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8433,7 +8455,7 @@
                 <Pin Id="Ex7ZxLowNfvLAqmCZT439Q" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="210,1454,70,19" Id="Vqkc9IfD17LLDCxPJjNX0k">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8465,7 +8487,7 @@
               <Link Id="JdjLncmfN5XPsBRiSrAARM" Ids="ArotmEKGp8wNp7IUxC7tZx,FyH0hRarQO0MUTlWhAJXCN" />
               <Link Id="VBldFL45FM4MtKuGolqJKV" Ids="De7w50BZSQdM19qbeMJSJk,QFPExXpSj3FOXy50l3Ugxz" />
               <Pin Id="O5fE2SvrCehNaZwXXhj3vB" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8475,19 +8497,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="S95wptH0TbCOXEchbM508g" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QE34V9gMGtONkYGJHl58TO" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="C8KtaNgBt6sPu64VBfKSxW" Name="Byte Index" Kind="InputPin" />
               <Pin Id="JMvWz16JI0VMZxoQxJPN58" Name="Args" Kind="OutputPin" />
               <Pin Id="Sx2GVjdpEYHM5UxAQlVPGt" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8500,7 +8522,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="532,1362,325,239" Id="IiA3aHpJaOMMTutp2HvufE">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="GzcA3tlwWpOM814QV8OhuM" IsGeneric="true">
@@ -8513,7 +8535,7 @@
               <ControlPoint Id="Bum4KIdrdcPM7AX8tX7Zdf" Bounds="762,1578" />
               <Link Id="Eodzu4SyFTFQMGPNtB8W7e" Ids="Bum4KIdrdcPM7AX8tX7Zdf,Mk2W7hg3rn9QJKQTO7plYT" IsHidden="true" />
               <Node Bounds="544,1533,70,26" Id="BCDpAzuJi1uMOZUPHlPNzd">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (3 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (3 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (3 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -8524,7 +8546,7 @@
                 <Pin Id="BMnqmZ2zWwhLb0AOdJHfj7" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="544,1408,70,19" Id="CCvdKghTGPSMOgFphYIGuj">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8537,7 +8559,7 @@
                 <Pin Id="TSerQ2FAvnINnjlRZTmvIt" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="578,1459,70,19" Id="QCeEUbSEXBKPbOPMP5VehU">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8557,7 +8579,7 @@
               <Link Id="AfgP4eBkInFQcN3rvIkzHu" Ids="TSerQ2FAvnINnjlRZTmvIt,Hpdb8aHAvDcOqxGMkXFnzB" />
               <Link Id="SsZsgglqGNLMUe7QzElT9y" Ids="BMnqmZ2zWwhLb0AOdJHfj7,MoL0q60NGQ3LH9anamVrnZ" />
               <Node Bounds="611,1499,70,19" Id="KnocHfz5u60LVASWrkMyG2">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8587,7 +8609,7 @@
               <Link Id="OTDOxic3jLELSeyPVkZXVX" Ids="TVLgqHm5PT3Nhy1eAmU0uL,QCrIzWGMLhjQWD6Wv1Fcqt" IsHidden="true" />
               <Link Id="E0ka3hSXEJDNfcVnm5cbln" Ids="QCrIzWGMLhjQWD6Wv1Fcqt,PeMZdwhin9tPK3HgjQq8nS" />
               <Pin Id="B9p79BJHyrfLuXEJJyGm0F" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8597,19 +8619,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="OONMLZyVyJyP4S9TIrGl1X" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="TVLgqHm5PT3Nhy1eAmU0uL" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="NoXenGizTKOOI5ujlT7cGY" Name="Byte Index" Kind="InputPin" />
               <Pin Id="S6Y61YHAFKWMk08iFtc2uK" Name="Args" Kind="OutputPin" />
               <Pin Id="AbmUMIwN55EPMkZaabwARx" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8622,7 +8644,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="895,1359,325,299" Id="TezdNjg0iY2NY415C0sl4o">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="LeieExANzxhNtzBoVFDOtr" IsGeneric="true">
@@ -8635,7 +8657,7 @@
               <ControlPoint Id="MADpkp1MmWONa8MeTCp8oe" Bounds="1125,1635" />
               <Link Id="QO78VKvwELdQWxLuHh2idY" Ids="MADpkp1MmWONa8MeTCp8oe,PBsWvdFDyqAL9giL4QxIgZ" IsHidden="true" />
               <Node Bounds="907,1590,70,26" Id="BJqFpgYtJFPLgPSbFSAGsC">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (4 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (4 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (4 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -8647,7 +8669,7 @@
                 <Pin Id="O0PghqLD6odPPSlMaL8puT" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="907,1405,70,19" Id="DlcrDxZrgm1O9ainKDhSi0">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8660,7 +8682,7 @@
                 <Pin Id="JzBxW0rPBnYLe1bRJS3VJ7" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="941,1456,70,19" Id="SYdrWCRPUXGMQW1SNbJm0u">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8680,7 +8702,7 @@
               <Link Id="ULUvJ5wIzpoOFNPzhLTB0A" Ids="JzBxW0rPBnYLe1bRJS3VJ7,AE5VddQPR3OObQBhkwbjRV" />
               <Link Id="PSLa2vPn4pnN77MhKNC6NL" Ids="O0PghqLD6odPPSlMaL8puT,OFEVMPshnJqQWAUvWPkMpt" />
               <Node Bounds="974,1496,70,19" Id="ED609SGATbWLvmkyG1YNxe">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8708,7 +8730,7 @@
               <Link Id="BWMKR5V6VNxPWQHcuT4yyB" Ids="QO2wDyXIhZMPNALK6F8yB1,OHsU9BwMeMsOEVkmQM4g7z" IsHidden="true" />
               <Link Id="J48lIVL4qHfLYF8ZlzhwgG" Ids="OHsU9BwMeMsOEVkmQM4g7z,E7VhMrcxOoBPv53iAqq8H5" />
               <Node Bounds="1001,1541,70,19" Id="D71blgzXLL7LyorRg2ynbh">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8728,7 +8750,7 @@
               <Link Id="TG9kEKowj1mLiS6gti0C0G" Ids="QpGONtpjg4bL3YcF4V1Al6,HR8MDKXMjyXQDEB3rcC2aJ" />
               <Link Id="EOiMEV5eQIdMHQTrqlVciP" Ids="J3pLJxoNedKODEcayX05EO,RUFPyo8gOqfOdWQFk7pBR3" />
               <Pin Id="CHRg7PDDK6aMOcMsDkxpew" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8738,19 +8760,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Spa8uJK39U7NIwKyP4Lkbj" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QO2wDyXIhZMPNALK6F8yB1" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="DTeVpH9EWFoP5C6V80DLRs" Name="Byte Index" Kind="InputPin" />
               <Pin Id="GAizjxSUeyNNJwd5AH4Uds" Name="Args" Kind="OutputPin" />
               <Pin Id="BW5FZXkqmcYQKXA2qoTnAI" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8763,7 +8785,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="1308,1358,328,338" Id="KPTvyIEXdV3Qb55w6lkGkL">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="OuSsTOJtwSBQLps1RATDos" IsGeneric="true">
@@ -8776,7 +8798,7 @@
               <ControlPoint Id="HyUvt6LgoWrLIOOpX5KvgU" Bounds="1541,1673" />
               <Link Id="CrMSYiAOz2QM60YPjv1L1R" Ids="HyUvt6LgoWrLIOOpX5KvgU,R1Uq0kFxqR9LwK3UeLMQrk" IsHidden="true" />
               <Node Bounds="1323,1628,85,26" Id="EHSchbclELQLGcvVOrvMHd">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (5 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (5 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (5 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -8789,7 +8811,7 @@
                 <Pin Id="IgDpZQlxvtaMuc9LqdmXRw" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="1320,1404,70,19" Id="Gz747d7oaeHNofMh1CqfhY">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8802,7 +8824,7 @@
                 <Pin Id="GS0OJWEnLW6M08nkfQ1bgO" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1354,1455,70,19" Id="Ktwyv4NspnDO8RHepus2i3">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8822,7 +8844,7 @@
               <Link Id="N6xOl3x7r1zM7y0QFMpjbv" Ids="GS0OJWEnLW6M08nkfQ1bgO,SGqEsesXOwuNQKnMIL3sw9" />
               <Link Id="IZYLCHThM9DMdvFvIx3s8u" Ids="IgDpZQlxvtaMuc9LqdmXRw,IUrTYLFw5zhQYIOY47FPw3" />
               <Node Bounds="1390,1496,70,19" Id="PLgI9QkHFD2OHhyMKFDXdH">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8851,7 +8873,7 @@
               <Link Id="KLI6IoDlENDNfbUJlDT9dr" Ids="R95909XLIhtL2OztTGE4nx,TbnEgQkog47QL7T6U0fgB7" IsHidden="true" />
               <Link Id="NiOQ2LKZu4EP9hc5s85wxB" Ids="TbnEgQkog47QL7T6U0fgB7,J4iAVnDlADtP3WnwWdtNoz" />
               <Node Bounds="1426,1537,70,19" Id="H1nXvJ4AXePMC3TPMfAokD">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8864,7 +8886,7 @@
                 <Pin Id="VCfGVuzDfRWOK9egrHepex" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1443,1583,70,19" Id="BKKdGkDpneBMiDDNYD2ogC">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8888,7 +8910,7 @@
               <Link Id="KGIs241mTzDLbJCmCBzAcu" Ids="RlXtA0P6EU5MiuV7eftlln,Bj7tbRzccSSNw1b7t8ZK5z" />
               <Link Id="AXPzoxSunr4Lo9rZVArMk1" Ids="G6F74ggsMk9L2dwd3JqpP9,MYfG7dPBHt2OiQDbrcyK35" />
               <Pin Id="DRkwQ5pzcACOzC1e34Kspv" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -8898,19 +8920,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="BCQ8ZeOIPQGNLQV0GxnJXl" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="R95909XLIhtL2OztTGE4nx" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Plkn3YFsMxMMjCCkMCRT69" Name="Byte Index" Kind="InputPin" />
               <Pin Id="MmOm8I2iIHpNcz3T7BX8Z8" Name="Args" Kind="OutputPin" />
               <Pin Id="SrCEgWsZWPVOXpa6Ivuyvl" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -8923,7 +8945,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="1701,1354,405,350" Id="LbU35es7REjOjEcms7SaP0">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="RgjNswdra5XPPcuaJcbybC" IsGeneric="true">
@@ -8936,7 +8958,7 @@
               <ControlPoint Id="FXryXFQ5riLLkCd8WVPPW0" Bounds="2011,1682" />
               <Link Id="Aw89ursdVSbOvZi9RLZWP3" Ids="FXryXFQ5riLLkCd8WVPPW0,RjUL6aII0alOx3tkLtPWVS" IsHidden="true" />
               <Node Bounds="1718,1636,105,26" Id="TvfQf79gdXZNrPhDi3VmID">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (6 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (6 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (6 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -8950,7 +8972,7 @@
                 <Pin Id="OTQMjjbfk8QMJ65y10QY7R" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="1713,1400,70,19" Id="P2gSrNsx9pULL72k8TQlW3">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8963,7 +8985,7 @@
                 <Pin Id="ARUT3Iy5pIaPFG2Ijscgco" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1747,1451,70,19" Id="GN8SbLnEcE2O48kppM6BFU">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -8983,7 +9005,7 @@
               <Link Id="JTxw3a65qmZQITnjZaFgjm" Ids="ARUT3Iy5pIaPFG2Ijscgco,MrZ8qnxICYDQGB03iO6wXU" />
               <Link Id="FjSjHpcEFesLjWx5SsUbUH" Ids="OTQMjjbfk8QMJ65y10QY7R,VCyBGEawRq3MHO5MHC8QG8" />
               <Node Bounds="1780,1491,70,19" Id="Sg87ZJj2AdlLsVuvzTJSZJ">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9011,7 +9033,7 @@
               <Link Id="JI1TO2Yez0YM3wHfooLiaU" Ids="QrrMP7kITGlOYZfbP7oRPM,OCKKuy7ORCOQIo3xEJsKmc" IsHidden="true" />
               <Link Id="VzR5VwM5WyiOI95zM9PjUP" Ids="OCKKuy7ORCOQIo3xEJsKmc,HXk1Hlmna19Nl8DlLnK4H3" />
               <Node Bounds="1795,1522,70,19" Id="OnOwRgYeUdhQVOYOdGCYR1">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9024,7 +9046,7 @@
                 <Pin Id="DgHyFerT4gTQdcjzbY6Bbo" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1831,1563,70,19" Id="OvjSPJ8rnjlMlZIBfb8Lvd">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9037,7 +9059,7 @@
                 <Pin Id="TC6hQLTuG21QArSNUbymjj" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="1849,1603,70,19" Id="Ney03R43LLEN7dYr5PHTeF">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9067,7 +9089,7 @@
               <Link Id="HTfW8oN1rrDNbWVgabHXSv" Ids="R40L5GnuDyaO66kBJvxMVS,KEb0sv3WTZJOOPOAGS7RPs" />
               <Link Id="Hrc6FHm0kfZNy1QKKCx335" Ids="QgX6jgfcLmaP3rcIndsaHB,FXryXFQ5riLLkCd8WVPPW0" />
               <Pin Id="C0NRqaBfYZDPdEKx6nB9gi" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -9077,19 +9099,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AIqwG57C8NsPrYvrglLwEN" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="QrrMP7kITGlOYZfbP7oRPM" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CNRPpVdZOk1N6iqur3Dnbk" Name="Byte Index" Kind="InputPin" />
               <Pin Id="EiWhbEj1BQdPQoGIuSAg8J" Name="Args" Kind="OutputPin" />
               <Pin Id="RTrgJYilqzONxZgbNV6DzK" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -9102,7 +9124,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="2162,1361,378,392" Id="PzABsqYodJrMRKMfkWBpSm">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="ROzmnAk7ZkHNXjU3vhU2Uq" IsGeneric="true">
@@ -9115,7 +9137,7 @@
               <ControlPoint Id="BOY1aMRgamcL3znCeMvMsJ" Bounds="2445,1725" />
               <Link Id="VIZthBlVnaaQR5uIfUYBPF" Ids="BOY1aMRgamcL3znCeMvMsJ,TAP5ZA3FMlYNRLNuR1f3Ps" IsHidden="true" />
               <Node Bounds="2177,1685,125,26" Id="J1699ZmY72PPAb25ZYQ3D4">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (7 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (7 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (7 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -9130,7 +9152,7 @@
                 <Pin Id="BMRjUtRlLNxLzJRT5Nf4gI" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="2174,1407,70,19" Id="L0mTdsl27GGMyBTPq0HNT1">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9143,7 +9165,7 @@
                 <Pin Id="RsO02bVHtJwM1Eyt6Mpq16" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2208,1458,70,19" Id="D6XYsyFtdNFP1NOZiRTzcF">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9163,7 +9185,7 @@
               <Link Id="IRyclHCCdSDQFEsMwj2YCF" Ids="RsO02bVHtJwM1Eyt6Mpq16,H1xEsA3gMCwLbtYJiy4BXy" />
               <Link Id="RbCjpSjFc7KLfsXDAr1Lg6" Ids="BMRjUtRlLNxLzJRT5Nf4gI,GCj1GQR0sAjNUdP9iRG3Xd" />
               <Node Bounds="2241,1498,70,19" Id="SDtrchN9YnvPNgn8OTe8bH">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9191,7 +9213,7 @@
               <Link Id="EZcrujZbajPQFjUX1NmmBM" Ids="J8zq2GfoF0zMgYJfb7OLFH,NIqbYq7b0muNdJUPBBfD70" IsHidden="true" />
               <Link Id="Ih0lprOIQMdLNiIOCEYhsa" Ids="NIqbYq7b0muNdJUPBBfD70,TzteKZr8fv9OUGOHUSJWWX" />
               <Node Bounds="2260,1534,70,19" Id="FB4zi2jWedPQUTx4QUYSss">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9204,7 +9226,7 @@
                 <Pin Id="Og9dgcvafC2OxfZfEuRKyL" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2275,1565,70,19" Id="MY33S4ZCiRjMFx7iMaD8wl">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9217,7 +9239,7 @@
                 <Pin Id="ASgWuaRC5yIObF8WZacLLL" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2311,1606,70,19" Id="PL1VUHUwITxNHD7xinszjF">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9230,7 +9252,7 @@
                 <Pin Id="GKVKfbqkhxLLQjQpnGPGxt" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2329,1646,70,19" Id="JmAfnZZhaiBMZIomEAcAy1">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9265,7 +9287,7 @@
               <Link Id="Gb5tXvR7wMONv7PLD5YFOs" Ids="QI4uCHJskQHMAUjIePp4ju,BXN0JqnILtMLmTioUwHSHG" />
               <Link Id="CKudJ6HBqsLL5zASTqRFsH" Ids="Clkq2W5TOzCMj8e14cfvEs,J7EwhhTVfpvNRKNrEYGltZ" />
               <Pin Id="Jh5ttOR2kWEPZHn9rWXt93" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -9275,19 +9297,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="PNVtM2smjzNOpZnraVPEsA" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="J8zq2GfoF0zMgYJfb7OLFH" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="MhIrBTIxriIPfcRFr6ndr5" Name="Byte Index" Kind="InputPin" />
               <Pin Id="M4wHqY9vmaJLdyNocCGnwS" Name="Args" Kind="OutputPin" />
               <Pin Id="EJUcry8TVVzMqLBYJ4T0dE" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -9300,7 +9322,7 @@
 
 -->
           <Node Name="DataToArgs" Bounds="2621,1359,418,465" Id="Ki4lV1Vg5pGOOsElE9Xp2C">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="Ni9YaBtbNwdOXi4J9dbuth" IsGeneric="true">
@@ -9313,7 +9335,7 @@
               <ControlPoint Id="BIuAsYnnbXONjPuX60iuhe" Bounds="2944,1805" />
               <Link Id="RAN3Sx6ezYbNlV2GCKS3Ht" Ids="BIuAsYnnbXONjPuX60iuhe,S8ZqCCcCzvqNdJl6zjdLae" IsHidden="true" />
               <Node Bounds="2642,1756,145,26" Id="S66mUSjENVrNej5x6andQL">
-                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (8 Items)" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.ValueTuple (8 Items)" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ValueTuple (8 Items)" />
                   <Choice Kind="OperationCallFlag" Name="ValueTuple (Create)" />
@@ -9329,7 +9351,7 @@
                 <Pin Id="S3uYfR4oUAUOGSfXl8afv7" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="2633,1405,70,19" Id="MTaDqnDXIOsMlu18zaCNr5">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9342,7 +9364,7 @@
                 <Pin Id="ESWQjDVVu8DNrT5bS05iwI" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2664,1445,70,19" Id="Qz3gzzmLLPNOvMnUeSSfhX">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9362,7 +9384,7 @@
               <Link Id="QzxAOrYJmBhMivEuSHSSt2" Ids="ESWQjDVVu8DNrT5bS05iwI,HRwLI1LbPNqLyihLLhZIWp" />
               <Link Id="NJeAugRtnKZMiBAlzFynU3" Ids="S3uYfR4oUAUOGSfXl8afv7,MU9lKD5o57oPIrKkZVKZOV" />
               <Node Bounds="2697,1485,70,19" Id="T44HHVONproNUGmUOTCdk9">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9390,7 +9412,7 @@
               <Link Id="NLYeP4Pq1Q0P0h468PXrhO" Ids="LxeMtUNndrUOV7MV8HpR4o,UXsiy0P5GETN0LfvZBo66v" IsHidden="true" />
               <Link Id="BrL6LYBDGKSM1bu4ijNpzC" Ids="UXsiy0P5GETN0LfvZBo66v,BA1soYEGcLWLMbXMuvGzZY" />
               <Node Bounds="2708,1529,70,19" Id="Sf1d67ETpqoNFKqmvtM8o0">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9403,7 +9425,7 @@
                 <Pin Id="VEkpQ4iD0pAPLQYHLcsgkI" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2727,1565,70,19" Id="KTQtBCJHWAVQL62Rw7UmCl">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9416,7 +9438,7 @@
                 <Pin Id="QAvjTWJPntvMzwYNrWorjx" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2742,1596,70,19" Id="Hj9Lj9Pb3LHNfWgpOahJOV">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9429,7 +9451,7 @@
                 <Pin Id="SS1HoEQtzgfQNwqKIzZXYO" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2778,1637,70,19" Id="Rliynsq4zBWLwpojJcHjSp">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9442,7 +9464,7 @@
                 <Pin Id="R55AccFlmQuLdXMDFqUCjA" Name="Next Byte Index" Kind="OutputPin" />
               </Node>
               <Node Bounds="2796,1677,70,19" Id="RvLcFsLuEFAP7iDawel2ft">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                 </p:NodeReference>
@@ -9482,7 +9504,7 @@
               <Link Id="KJPzs2MqIc3LftnO1wWelq" Ids="VCv0wHlwcDmNRj7umElJwf,OtuG6s3A1xeLbVPCMyevbo" />
               <Link Id="IKNtMcmOAR0Oo5wFaIpbof" Ids="CsZzl0yA9IJMEIFOZBb64S,BIuAsYnnbXONjPuX60iuhe" />
               <Pin Id="KsHVYR1EptyQcvDWNjSCbT" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -9492,19 +9514,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="RohxiKqW4HAOVCapcFkt9f" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="LxeMtUNndrUOV7MV8HpR4o" Name="TypeTag Index" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="GXzHSwG80cyPNShumHGaei" Name="Byte Index" Kind="InputPin" />
               <Pin Id="Rz286jEpXYINsuIKoIbIuv" Name="Args" Kind="OutputPin" />
               <Pin Id="URLSnpHMncxPfEEwF4FxlL" Name="Next TypeTag Index" Kind="OutputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -9518,13 +9540,13 @@
 
 -->
         <Node Name="EncodeOSCMessage" Bounds="376,453,263,249" Id="GxdMRFWSnmHOtgGSdaBRGA">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="FsRqUONfoStPSj2VNlErsS" IsGeneric="true">
             <ControlPoint Id="NH678ieQY62PnGKwHaPI2R" Bounds="566,547" />
             <Node Bounds="497,585,70,19" Id="NQhrPYd0nyfMFTEbuaA19f">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="ArgsToData" />
               </p:NodeReference>
@@ -9533,7 +9555,7 @@
               <Pin Id="Q6U85fmbjDZOiMYezAb6Rf" Name="Context" Kind="OutputPin" />
             </Node>
             <Node Bounds="497,622,88,26" Id="KfRD3W5NpEELNwbvz4dDsA">
-              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetBytes" />
               </p:NodeReference>
@@ -9542,7 +9564,7 @@
               <Pin Id="BmxNBzQJcsTOO7m3NwULvc" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="454,476,88,26" Id="Fi6dbywFKRjL5hO0QTGQed">
-              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" />
                 <Choice Kind="OperationCallFlag" Name="Create" />
@@ -9558,7 +9580,7 @@
             <ControlPoint Id="EZRZ6qrHC99QYXAXLj7UGt" Bounds="390,506" />
             <Link Id="PL7nYETFmG0QdUU2l2jaEO" Ids="VwU05lOxmwfP0mWQ7hDqxB,EZRZ6qrHC99QYXAXLj7UGt" IsHidden="true" />
             <Node Bounds="454,532,88,26" Id="H3DF0b9XEQjOqm2K9LDCje">
-              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC.SerializationContext" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="SetAddress" />
                 <CategoryReference Kind="ClassType" Name="SerializationContext" NeedsToBeDirectParent="true" />
@@ -9581,12 +9603,12 @@
 
 -->
         <Node Name="MatchAll" Bounds="1075,443,231,441" Id="MXFBNZ2BS14O7Ef0YCUr5M">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="ScyDgfPLYXkOr4terzouEL" IsGeneric="true">
             <Node Bounds="1119,484,124,113" Id="KDF40Urxrk4OyHejwRg7oj">
-              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Where" />
                 <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -9597,7 +9619,7 @@
                 <ControlPoint Id="QAotI0xI3XQPutjjT3eXcf" Bounds="1133,492" />
                 <ControlPoint Id="ATUomT2IxNlPqQL8LBXoQ3" Bounds="1153,590" />
                 <Node Bounds="1151,550,80,19" Id="F4Gdn18iq68MOjuo7DJAFH">
-                  <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="MatchAddress" />
                   </p:NodeReference>
@@ -9606,7 +9628,7 @@
                   <Pin Id="RMMsC3Elq9iNqMaMLtuljH" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1131,510,65,26" Id="Rc8bzlXbFtQNuewNCAy4WT">
-                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9623,7 +9645,7 @@
               </Patch>
             </Node>
             <Node Bounds="1119,655,120,134" Id="Cq6tsdILZQAL70R9kqU0cR">
-              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationCallFlag" Name="Select" />
                 <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -9638,7 +9660,7 @@
                 <ControlPoint Id="Cvqw6bfm2jOLYfLB1gJrWI" Bounds="1193,663" />
                 <ControlPoint Id="IH06V46zIkgLkPaFZVpfVt" Bounds="1132,782" />
                 <Node Bounds="1131,737,70,19" Id="AwO1NW29bWNPHHP9Qa9m92">
-                  <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                   </p:NodeReference>
@@ -9651,7 +9673,7 @@
                   <Pin Id="KzFyYSEtgRRLaN7wiDwLhD" Name="Next Byte Index" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="1132,688,65,26" Id="IAqXvcjGwHWOd75BW4NP6B">
-                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9691,7 +9713,7 @@
             <Pin Id="HxTZ2BRStAyPO9np21ekFj" Name="Output" Kind="OutputPin" Bounds="1426,1293" />
             <Link Id="AOd78hZ9MpbOn8H7jhHY9A" Ids="ESFM5yfgGJONYFa7EMBHJa,HxTZ2BRStAyPO9np21ekFj" IsHidden="true" />
             <Node Bounds="1119,815,83,26" Id="IrmGb9gymNBN9XOnbuluZr">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FromSequence" />
                 <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -9704,7 +9726,7 @@
             <Pin Id="J9p007w9cuCP7fDtFgiz1z" Name="Is Matched" Kind="OutputPin" Bounds="952,729" />
             <Link Id="GhVHFXTcZTgOiLSzo36hUb" Ids="U656Ygu7hwYMaGlxBBpEJD,J9p007w9cuCP7fDtFgiz1z" IsHidden="true" />
             <Node Bounds="1228,812" Id="FT1unudlppLLfh1PiqF9vT">
-              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Any" />
                 <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -9722,7 +9744,7 @@
 
 -->
         <Node Name="MatchLast" Bounds="715,442,309,441" Id="HzinR9XNijdNgO9D9kFdNV">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="BsMMsSl6saGN9g8xO8kQ4j" IsGeneric="true">
@@ -9731,7 +9753,7 @@
             <ControlPoint Id="SyRnUiiqmnnNfZV6n7841P" Bounds="964,506" />
             <Link Id="EcnDSQT9W4VLNeZF8gEgzu" Ids="R7BfY7KJst6QYpXb1jORmp,SyRnUiiqmnnNfZV6n7841P" IsHidden="true" />
             <Node Bounds="794,514,124,113" Id="P6qQVVTI2cZPD3D1OacUEd">
-              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="OperationCallFlag" Name="LastOrDefault (Predicate)" />
                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               </p:NodeReference>
@@ -9745,7 +9767,7 @@
                 <ControlPoint Id="RPv3fQMhT5uOBFAsX2gvkw" Bounds="808,522" />
                 <ControlPoint Id="FitA9BWP7FWPDLpkILFhpJ" Bounds="828,620" />
                 <Node Bounds="826,580,80,19" Id="CfnUjA6BjaSL1O6P6w7lUH">
-                  <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="MatchAddress" />
                   </p:NodeReference>
@@ -9754,7 +9776,7 @@
                   <Pin Id="ENzecjE6kTIMKcU0ztCZlt" Name="Result" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="806,540,65,26" Id="LHo1binQw0AOFs25gyJ1nQ">
-                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9768,14 +9790,14 @@
               </Patch>
             </Node>
             <Node Bounds="913,465,40,19" Id="CDBVYyRsfHnQZJFCvFyl5W">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="NULL" />
               </p:NodeReference>
               <Pin Id="GgjFoiujT5jLHcQY16MOdl" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="801,661,65,19" Id="UltPKLrSbprMD0VMICLs3V">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
               </p:NodeReference>
@@ -9784,7 +9806,7 @@
               <Pin Id="EeVebMjLH2HN6iRowFRc9i" Name="Not Assigned" Kind="OutputPin" />
             </Node>
             <Node Bounds="801,714,108,132" Id="EOSkLb2GWq4PdJNAoHBDQE">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -9796,7 +9818,7 @@
                 <Patch Id="U0m1QRVHrp4QIzG33It2zi" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="QEuOXjJqbBBLpEp0J5B0Vt" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="813,804,70,19" Id="Af23FA5dGgFOYFqdWidBn9">
-                  <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                   </p:NodeReference>
@@ -9809,7 +9831,7 @@
                   <Pin Id="O1yCUQSeka4Lkt9D9RtQPG" Name="Next Byte Index" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="832,738,65,26" Id="IhfyJydhPNYNTLpbRNjPk1">
-                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="OSCMessage" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -9844,7 +9866,7 @@
             <Link Id="EUoPMZTirx9QUO7XOSAPnv" Ids="SlFgFDoOjoVOjRPzDujF7W,PEQjOYqdf12LTAcTFFrVwV" />
             <Link Id="ENVswrrujcVNH3JCD2vSVq" Ids="PEQjOYqdf12LTAcTFFrVwV,VxL3wBYyFP6NMevSYD8c72" IsHidden="true" />
             <Pin Id="GNcLTGWxR4fPv1VhTE7ep7" Name="Input" Kind="InputPin" Bounds="439,915">
-              <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Sequence" />
                 <p:TypeArguments>
                   <TypeReference>
@@ -9864,13 +9886,13 @@
 
 -->
         <Node Name="SerializationContext" Bounds="479,348" Id="HFAxQlE5hFxNhPy0P9ICtI">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ClassDefinition" Name="Class" />
           </p:NodeReference>
           <Patch Id="BOIB33JEax0NmtqmmBf6ek" IsGeneric="true">
             <Canvas Id="EfnWlAJEH3nPQ5e4lAHWGU" CanvasType="Group">
               <Node Bounds="178,463,64,19" Id="J55VETc8cDjM2Pn3yqTeHl">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackString" />
                 </p:NodeReference>
@@ -9879,7 +9901,7 @@
               </Node>
               <Pad Id="PZRtdIGBe8wPm0vE0cfAbC" SlotId="Ml4Bc0K7e1xMMG1x7ZgGzj" Bounds="335,365" />
               <Node Bounds="581,517,66,26" Id="PtuM6qnxlKnNBjXAuZHeDQ">
-                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="AddRange" />
                   <FullNameCategoryReference ID="Collections.Builder.SpreadBuilder" />
                 </p:NodeReference>
@@ -9891,7 +9913,7 @@
               <ControlPoint Id="J8eE8c5CbHtLtdXrfjFTP3" Bounds="385,368" />
               <ControlPoint Id="Vq3XS4P6ijsPjxjt2htJZK" Bounds="644,491" />
               <Node Bounds="270,584,64,19" Id="ND6fNzVvwuyMHRohdjxO6z">
-                <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationNode" Name="PackString" />
                 </p:NodeReference>
@@ -9899,7 +9921,7 @@
                 <Pin Id="PA8voxFa8apM58twwz8nzQ" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="360,394,25,19" Id="G3Wu9gX6S6OOhASzEf9IBT">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
@@ -9908,7 +9930,7 @@
                 <Pin Id="GvkDQxZCVdNNmQtMPCuqAG" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="366,569,83,26" Id="QOUpspEIAgiQRTuL6HAs5i">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="FromSequence" />
                   <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -9918,7 +9940,7 @@
               </Node>
               <ControlPoint Id="Jwud5JtZ3PcPEoTlHAawRA" Bounds="251,700" />
               <Node Bounds="547,372,66,26" Id="Qyqz0vycblJO4D5ICe5RUu">
-                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="OperationNode" Name="Create" />
                   <FullNameCategoryReference ID="Collections.Builder.SpreadBuilder" />
                 </p:NodeReference>
@@ -9929,12 +9951,12 @@
               <Pad Id="Lcg9UiP7IHdO1OxMr9j9XL" Bounds="180,542" />
               <Pad Id="DnrCkG2Aw5gNHPGiTk9oQl" SlotId="Ml4Bc0K7e1xMMG1x7ZgGzj" Bounds="337,439" />
               <Node Bounds="270,549,25,19" Id="PMDoLNZtIUPNiRDvMhagSt">
-                <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="+" />
                 </p:NodeReference>
                 <Pin Id="Qe3kiqmCDbeOX5zTFpdatl" Name="Input" Kind="InputPin" DefaultValue=",">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -9942,7 +9964,7 @@
                 <Pin Id="KoGOcfTOuPOOnY9I6H8JOA" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="249,648,45,19" Id="G8Yi1MG9NDdMWrEurU82GN">
-                <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
                   <Choice Kind="OperationCallFlag" Name="Concat" />
@@ -9953,7 +9975,7 @@
                 <Pin Id="JVNH8PYwXJbMIUoGNmB5sE" Name="Output" Kind="OutputPin" />
               </Node>
               <Node Bounds="621,436" Id="NtgaG1lyJfFNrPky0utu2Z">
-                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastSymbolSource="VL.Collections.vl">
+                <p:NodeReference LastCategoryFullName="Collections.Builder.SpreadBuilder" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Clear" />
                   <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
@@ -9962,7 +9984,7 @@
                 <Pin Id="IBCFLds48oPQEw5MKUmKXW" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Pad Id="UVCShewDlBPLnLuXFt6juX" Comment="TypeTags" Bounds="335,317,35,15" ShowValueBox="true" isIOBox="true" Value="">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
@@ -10000,12 +10022,12 @@
             <Patch Id="LCEIyNRSXKcMS27s3HsJ6y" Name="Create" ParticipatingElements="Qyqz0vycblJO4D5ICe5RUu" />
             <Patch Id="Vm676ZMDGXONdZSIlFHGXS" Name="AddArguments" ParticipatingElements="PtuM6qnxlKnNBjXAuZHeDQ,G3Wu9gX6S6OOhASzEf9IBT">
               <Pin Id="Uh13tgRfBJ6NESc3RBmGv1" Name="TypeTags" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="AXGBruHvA03LaEDf4Va4NS" Name="Data" Kind="InputPin">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Sequence" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -10030,7 +10052,7 @@
 
 -->
         <Node Name="MatchAddress" Bounds="376,808,298,134" Id="ThGrpEvekvSNSvVqSamvto">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="FjBNpRfpvVvNignUlFYCzE">
@@ -10041,7 +10063,7 @@
             <ControlPoint Id="CR2rkQIgxKVOSlESJDCBHZ" Bounds="394,830" />
             <Link Id="UVVfYT4xsrdO7GFCQ71ynR" Ids="PMndgXUzSf8OgN1KiOJZt2,CR2rkQIgxKVOSlESJDCBHZ" IsHidden="true" />
             <Node Bounds="390,872,80,19" Id="JW1PLVDIPOcMQJpmJE4ruR">
-              <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastSymbolSource="VL.IO.OSC.dll">
+              <p:NodeReference LastCategoryFullName="VL.IO.OSC.OSCUtils" LastDependency="VL.IO.OSC.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="OSCUtils" />
                 <Choice Kind="OperationCallFlag" Name="MatchAddress" />
@@ -10134,7 +10156,7 @@
 
 -->
         <Node Name="OSCReceiver (Reactive)" Bounds="149,201" Id="OdTddaZvpAJO4k20op1eVP" Summary="Receives the arguments from the specified OSC address" Remarks="Connect to an OSCServer">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="RSKQ8hjSFf0PPxJ8ZRKH0m" IsGeneric="true">
@@ -10142,7 +10164,7 @@
               <ControlPoint Id="CjNMs0j5noMQUOxxphYOfa" Bounds="546,1254" />
               <ControlPoint Id="PK4UwCQLLjzOnooG3CRpCN" Bounds="176,311" />
               <Node Bounds="448,127,56,19" Id="PGV4UiCqrxpODwLivLJXq2">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="TogEdge" />
                 </p:NodeReference>
@@ -10153,7 +10175,7 @@
               <ControlPoint Id="NWRJhvZDSr4PQp8aWNiQM6" Bounds="450,101" />
               <ControlPoint Id="JAObYOKOCaJNYEhtblpFDg" Bounds="57,423" />
               <Node Bounds="55,446,63,26" Id="TmUaUnbL35fLXwt2o9GKox">
-                <p:NodeReference LastCategoryFullName="System.Reflection.NodeContext" LastSymbolSource="System.Reflection.vl">
+                <p:NodeReference LastCategoryFullName="System.Reflection.NodeContext" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="NodeContext" />
                   <Choice Kind="OperationCallFlag" Name="Path" />
@@ -10162,7 +10184,7 @@
                 <Pin Id="VKDf2kCiXaPPRd0dE32rnc" Name="Path" Kind="OutputPin" />
               </Node>
               <Node Bounds="55,487,51,26" Id="VL7WcA6hP3iNOXUqetamH0">
-                <p:NodeReference LastCategoryFullName="System.Reflection.NodePath" LastSymbolSource="System.Reflection.vl">
+                <p:NodeReference LastCategoryFullName="System.Reflection.NodePath" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="NodePath" />
                   <Choice Kind="OperationCallFlag" Name="Stack" />
@@ -10175,7 +10197,7 @@
               <ControlPoint Id="J0b1pMrUZOrOlsGb1Dcs2G" Bounds="637,279" />
               <ControlPoint Id="DFeLp4SOjmSMddvrbdmLxN" Bounds="792,272" />
               <Node Bounds="284,304,609,723" Id="UVQDjXH8xvtLdGHeacesp0">
-                <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                   <CategoryReference Kind="Category" Name="Primitive" />
@@ -10190,7 +10212,7 @@
                   <Patch Id="B28uDJUEK7XPlQsSlgwbGK" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="Tcq4OhEv6ycLAy7fPBK2Fe" Name="Then" ManuallySortedPins="true" />
                   <Node Bounds="327,462,554,529" Id="V5vjTnQ1FOYN6BSYD4vVog">
-                    <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                    <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="OperationCallFlag" Name="Select (Many)" />
                       <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" NeedsToBeDirectParent="true" />
                       <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -10205,7 +10227,7 @@
                       <ControlPoint Id="AKGmM8WSkzQMOu3ESwbeSW" Bounds="499,470" />
                       <ControlPoint Id="LXwbVM2k2xRNzMDvvy7GxO" Bounds="341,984" />
                       <Node Bounds="339,931,57,26" Id="AfGBgkAswL8Lkx0UoTELbf">
-                        <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                        <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="StartWith" />
                         </p:NodeReference>
@@ -10214,7 +10236,7 @@
                         <Pin Id="EnQn2w6iJCWNiyZx4ysaH4" Name="Output" Kind="StateOutputPin" />
                       </Node>
                       <Node Bounds="441,534,428,316" Id="EPrSwGzyHR0ObIZ5hgpL38">
-                        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="If" />
                           <CategoryReference Kind="Category" Name="Primitive" />
@@ -10224,7 +10246,7 @@
                           <Patch Id="NwM57vM2bKBOTv6hSEcrWS" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="Lam1LznG4uoL6S25cjkp7Q" Name="Then" ManuallySortedPins="true" />
                           <Node Bounds="575,761,69,26" Id="Ihlw6M9prlWM0GR6mswwRR">
-                            <p:NodeReference LastCategoryFullName="VL.ISolution" LastSymbolSource="VL.Lang.vl">
+                            <p:NodeReference LastCategoryFullName="VL.ISolution" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationNode" Name="SetPinValue (OrFurtherOutwards)" />
                             </p:NodeReference>
@@ -10235,21 +10257,21 @@
                             <Pin Id="LnIYiMf5jS4N4YhigbNGTY" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Node Bounds="575,804,53,26" Id="IjJUpEMqerwPlhsPsTOZ02">
-                            <p:NodeReference LastCategoryFullName="VL.ISolution" LastSymbolSource="VL.Lang.vl">
+                            <p:NodeReference LastCategoryFullName="VL.ISolution" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="MutableInterfaceType" Name="ISolution" />
                               <Choice Kind="OperationCallFlag" Name="Confirm" />
                             </p:NodeReference>
                             <Pin Id="PCvxsJewrw6PqZ5PPWuUNJ" Name="Input" Kind="StateInputPin" />
                             <Pin Id="Eat3SpIzgpWLmR9U5xQJmg" Name="Solution Update Kind" Kind="InputPin" DefaultValue="TweakLast">
-                              <p:TypeAnnotation LastCategoryFullName="VL.Model" LastSymbolSource="VL.Lang.dll">
+                              <p:TypeAnnotation LastCategoryFullName="VL.Model" LastDependency="VL.Core.dll">
                                 <Choice Kind="TypeFlag" Name="SolutionUpdateKind" />
                               </p:TypeAnnotation>
                             </Pin>
                             <Pin Id="IXYP4sDfs7bPAM77hnSiad" Name="Output" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="575,725,99,19" Id="R7aoxWFueSXNpChCOzti66">
-                            <p:NodeReference LastCategoryFullName="VL.Session" LastSymbolSource="VL.Lang.vl">
+                            <p:NodeReference LastCategoryFullName="VL.Session" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="Category" Name="VL" />
                               <Choice Kind="OperationCallFlag" Name="CurrentSolution" />
@@ -10257,12 +10279,12 @@
                             <Pin Id="M2SGU29pBSnNfp1W3H6DT9" Name="Current Solution" Kind="OutputPin" />
                           </Node>
                           <Pad Id="H1AzRxj9yOuM9kjAVN0fYc" Comment="Pin" Bounds="694,734,45,15" ShowValueBox="true" isIOBox="true" Value="Address">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="String" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Node Bounds="588,645,51,26" Id="PbYhGrFDko1L0fDP5vq8Db">
-                            <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                            <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="SetData" />
                             </p:NodeReference>
@@ -10271,7 +10293,7 @@
                             <Pin Id="GVTLblfqpeeP4By2cqCcQh" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Node Bounds="710,606,51,26" Id="QuD2RbFx20oMCnlLuLxN7f">
-                            <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                            <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="SetData" />
                             </p:NodeReference>
@@ -10280,12 +10302,12 @@
                             <Pin Id="Ee0535Ti9AMNqkYHHYgCnz" Name="Output" Kind="StateOutputPin" />
                           </Node>
                           <Pad Id="U7qhs7JeMqzQNDt4JgI8j6" Comment="Learning" Bounds="760,569,35,35" ShowValueBox="true" isIOBox="true" Value="False">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Boolean" />
                             </p:TypeAnnotation>
                           </Pad>
                           <Node Bounds="453,557,80,19" Id="Ko24gHFif3XPUlu6iYfNLW">
-                            <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                            <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="FirstOrDefault" />
                               <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -10296,7 +10318,7 @@
                             <Pin Id="T9KPSGmkIPLP7RWdhX3qaS" Name="Result" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="517,598,65,26" Id="U6PWGq8a2iINYHoODyJuD8">
-                            <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                            <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <CategoryReference Kind="RecordType" Name="OSCMessage" />
                               <Choice Kind="OperationCallFlag" Name="Split" />
@@ -10310,7 +10332,7 @@
                         </Patch>
                       </Node>
                       <Node Bounds="391,882,65,26" Id="Hb1m6xBwDmfMjJXDf1J0Qc">
-                        <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+                        <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="FromValue" />
                           <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -10321,7 +10343,7 @@
                     </Patch>
                   </Node>
                   <Node Bounds="328,342,56,26" Id="No7Cby2ZaLhOmq0LEGETZu">
-                    <p:NodeReference LastCategoryFullName="Reactive.Observable" LastSymbolSource="VL.Reactive.vl">
+                    <p:NodeReference LastCategoryFullName="Reactive.Observable" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="Category" Name="Reactive" />
                       <CategoryReference Kind="ImmutableInterfaceType" Name="Observable" />
@@ -10329,14 +10351,14 @@
                     </p:NodeReference>
                     <Pin Id="V2xwSln8GgDNUnofaO8nUh" Name="Input" Kind="InputPin" />
                     <Pin Id="Oz1qi7va8hgOn2ejh2Aaxu" Name="Count" Kind="InputPin" DefaultValue="1">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Integer32" />
                       </p:TypeAnnotation>
                     </Pin>
                     <Pin Id="GHVYzPdxB6UNNxW1FDlmr6" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="589,328,51,26" Id="H4T6hwrrYFeODwh3dnz7m1">
-                    <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="SetData" />
                     </p:NodeReference>
@@ -10347,7 +10369,7 @@
                 </Patch>
               </Node>
               <Node Bounds="589,84,51,26" Id="QKP9OSfBIObQZVWbWMPi1N">
-                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Reference" />
                   <Choice Kind="OperationCallFlag" Name="Create" />
@@ -10357,7 +10379,7 @@
               </Node>
               <Pad Id="HfK3jZxioe9PX1lN1IzvWX" SlotId="P090ettqXGTMHeclZmEHXa" Bounds="591,140" />
               <Node Bounds="284,262,54,19" Id="FIjEDCIhWpOQHPT24MRlCi">
-                <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="OnOpen" />
                 </p:NodeReference>
@@ -10366,7 +10388,7 @@
               </Node>
               <Pad Id="Nh8XxjEgOOEPWVLZOQbQ1X" SlotId="PqkADzBKf4bNNi4QM3shbA" Bounds="709,140" />
               <Node Bounds="707,84,51,26" Id="ESnJHgwpII5LJWKmQ3lebf">
-                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Create" />
                   <CategoryReference Kind="ClassType" Name="Reference" NeedsToBeDirectParent="true" />
@@ -10375,13 +10397,13 @@
                 <Pin Id="CKOifyl2t7uQKM4a4GS5nk" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="743,186,51,26" Id="SPCRPdERwVdOsl74jv1UiN">
-                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="SetData" />
                 </p:NodeReference>
                 <Pin Id="AODM21PyaO9NkuKLclSq6S" Name="Input" Kind="StateInputPin" />
                 <Pin Id="LwKZi2c2RoIQVl7JQiB780" Name="Data" Kind="InputPin" DefaultValue="True">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pin>
@@ -10389,7 +10411,7 @@
                 <Pin Id="PDt8ouUvfoZMO9iiBHiWTH" Name="Output" Kind="StateOutputPin" />
               </Node>
               <Node Bounds="743,223,51,26" Id="NH8TGmgTVJgPl32sb68eyE">
-                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="Data" />
                   <CategoryReference Kind="ClassType" Name="Reference" NeedsToBeDirectParent="true" />
@@ -10399,7 +10421,7 @@
                 <Pin Id="Vrj6FnutbIPMV2eN3I5wV4" Name="Data" Kind="OutputPin" />
               </Node>
               <Node Bounds="308,1105,184,353" Id="Oqr4IH3J6U6OsxzDBUZo0j">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ForEach" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -10416,7 +10438,7 @@
                   <ControlPoint Id="HwlhzSkKPZHP2T2SBI7Mai" Bounds="363,1134" />
                   <ControlPoint Id="KkSwtQhbhV1OcGkQdUVvaa" Bounds="343,1451" />
                   <Node Bounds="429,1128,51,26" Id="AECycthnXXhOJch5DUCpwv">
-                    <p:NodeReference LastCategoryFullName="Primitive.Reference" LastSymbolSource="CoreLibBasics.vl">
+                    <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="ClassType" Name="Reference" />
                       <Choice Kind="OperationCallFlag" Name="Data" />
@@ -10426,7 +10448,7 @@
                     <Pin Id="Jjuj74Fl6MIMSWxRzij6ZR" Name="Data" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="360,1189,56,19" Id="AXTZM0pgQ7mPm8USZjMzTc">
-                    <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                    <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="MatchAll" />
                     </p:NodeReference>
@@ -10436,7 +10458,7 @@
                     <Pin Id="EqvcPAMhOvvM9n9p67WqsC" Name="Is Matched" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="360,1274,80,86" Id="GRe1tG5bESgLpZIwQtFxJL">
-                    <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                       <CategoryReference Kind="Category" Name="Primitive" />
@@ -10448,7 +10470,7 @@
                       <Patch Id="D4QFCRQSKLhNsOmexMP8hQ" Name="Update" ManuallySortedPins="true" />
                       <Patch Id="UoGbMJYg7auLTlrWjloXWj" Name="Dispose" ManuallySortedPins="true" />
                       <Node Bounds="372,1312,51,26" Id="Lst48hoFMYONgeMVGJghCR">
-                        <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastSymbolSource="VL.Reactive.vl">
+                        <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="OnNext" />
                           <CategoryReference Kind="ClassType" Name="Subject" NeedsToBeDirectParent="true" />
@@ -10460,7 +10482,7 @@
                     </Patch>
                   </Node>
                   <Pad Id="E7G4NX8aNweMFLE2Us0SoT" Comment="" Bounds="345,1402,35,35" ShowValueBox="true" isIOBox="true">
-                    <p:TypeAnnotation>
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                       <FullNameCategoryReference ID="Primitive" />
                     </p:TypeAnnotation>
@@ -10472,7 +10494,7 @@
               </Node>
               <ControlPoint Id="VNFvF3pXp1QNSsuRxsHnUa" Bounds="743,1059" />
               <Node Bounds="546,1139,46,26" Id="NO2waxbCPlSN2wHyRRZE3d">
-                <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastSymbolSource="VL.Reactive.vl">
+                <p:NodeReference LastCategoryFullName="Reactive.Subjects.Subject" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Subject" />
                   <Choice Kind="OperationCallFlag" Name="Create" />
@@ -10550,7 +10572,7 @@
             </Patch>
             <Patch Id="HKu1lX8wQYbQXeyi8qXQAL" Name="Update" ManuallySortedPins="true">
               <Pin Id="NMVt67EQ0dVOJBe3CZEFTr" Name="Input" Kind="InputPin" Bounds="445,239">
-                <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Observable" />
                   <p:TypeArguments>
                     <TypeReference>
@@ -10567,7 +10589,7 @@
               <Pin Id="R1wzxpnNQ3JMyCbQivCjyc" Name="Address" Kind="InputPin" />
               <Pin Id="Ri7xCHfsIGFOocRXJt5uMc" Name="Learn" Kind="InputPin" Bounds="604,345" />
               <Pin Id="ErJMA9TnfvWNYP8pVZVdF9" Name="Output" Kind="OutputPin" Bounds="398,558">
-                <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+                <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Observable" />
                 </p:TypeAnnotation>
               </Pin>
@@ -10582,12 +10604,12 @@
 
 -->
         <Node Name="ParseByTypetag" Bounds="396,1143,158,1290" Id="Gz3Puv3iWKCL0hRoFabwql">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="Pt7UwSrYvxBLHpDDYKtyfM">
             <Pad Id="GAZM30ZqjE9MS1BeWdi9uB" Comment="" Bounds="488,1213,20,15" ShowValueBox="true" isIOBox="true" Value="f">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ImmutableTypeFlag" Name="String" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:TypeAnnotation>
@@ -10599,7 +10621,7 @@
             <ControlPoint Id="F7Rm7nk7lzRLa8Wo3k2A9D" Bounds="462,1182" />
             <Link Id="IzWBHLRTQjyLi9vyf4NYVU" Ids="QcvLVUhDP9ULYIfhok9kT4,F7Rm7nk7lzRLa8Wo3k2A9D" IsHidden="true" />
             <Node Bounds="408,1227,83,19" Id="AdKnR2Uus88Nh0UElrMjsn">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10616,7 +10638,7 @@
             <Link Id="AMQ11OD1mp3N6ILRHVzwSN" Ids="GAZM30ZqjE9MS1BeWdi9uB,AsL4mnVRudhL0WKgo52slp" />
             <Link Id="IAXLrEVpcMgOwuKfh9qY1x" Ids="F7Rm7nk7lzRLa8Wo3k2A9D,MDnBtWr7sbvNFyVu4SsITj" />
             <Node Bounds="408,1452,83,19" Id="EKbbMV3UppNN01aUxSIvai">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10630,25 +10652,25 @@
               <Pin Id="MP6Mb7KUpZ6L87A11jhoeb" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="CcTcCr5PeOxPFK9LJ4b58x" Comment="" Bounds="488,1436,35,15" ShowValueBox="true" isIOBox="true" Value="ff">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="IFJn63uDlgJMbWc1FMYry6" Ids="CcTcCr5PeOxPFK9LJ4b58x,VtAY8gQPWSHMIrYWVoJVJM" />
             <Pad Id="SxQqzx4HTlgOFbZf5VMgqd" Bounds="488,1486">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector2" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="Jwcnqr105dJO0RSr0Tw4vB" Ids="MP6Mb7KUpZ6L87A11jhoeb,SxQqzx4HTlgOFbZf5VMgqd" />
             <Pad Id="D5ia6pM7u63PHMprmV9GrR" Bounds="488,1262">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="OnxQ9nXjwTzL4XEk6r10Mk" Ids="DKl9MZO2GPFLJfJA1Z0TrP,D5ia6pM7u63PHMprmV9GrR" />
             <Node Bounds="408,1749,83,19" Id="MylP0EghP6DM7xBr5inyiu">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10662,19 +10684,19 @@
               <Pin Id="TiO5OiX3TbAP1Gbay0wULi" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="ESZooarsb44PZFtshKinJJ" Comment="" Bounds="488,1733,35,15" ShowValueBox="true" isIOBox="true" Value="i">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="AglrioQEdYnOHjWIEQzryl" Bounds="488,1786">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="PsHrLMXVcJcM3hEyLK7FWz" Ids="ESZooarsb44PZFtshKinJJ,Dn3TuU98vAaOb0si9hsGvC" />
             <Link Id="G9R0Zb6VitBP6UvLrb0qZe" Ids="TiO5OiX3TbAP1Gbay0wULi,AglrioQEdYnOHjWIEQzryl" />
             <Node Bounds="408,1920,83,19" Id="BQShSgOkclbLO09JIC3XzH">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10688,19 +10710,19 @@
               <Pin Id="B6iMwd3tEDTMtk5UqcmRr5" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="GadAn1SPpowQCGWCyL59GG" Comment="" Bounds="488,1903,35,15" ShowValueBox="true" isIOBox="true" Value="r">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="Vq8eozZl9mdM5zeDt2MbcT" Bounds="488,1956">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="RGBA" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="IgjXtHmUj6INlLEtP1N5CL" Ids="GadAn1SPpowQCGWCyL59GG,AMQsSjzvV6MQDRfakNCacw" />
             <Link Id="VQvb0jkWEWtOY7g6wDHvQe" Ids="B6iMwd3tEDTMtk5UqcmRr5,Vq8eozZl9mdM5zeDt2MbcT" />
             <Node Bounds="408,1546,83,19" Id="DoAf5insA83PFJkwWb7IFH">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10714,19 +10736,19 @@
               <Pin Id="ATWzF8ZUYf3LSWb1ZwyKqM" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="VFZzTsbHxeBOE9Q9aCyEXi" Comment="" Bounds="488,1530,35,15" ShowValueBox="true" isIOBox="true" Value="fff">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="Ni7aLKZmjQAL6vvF7WXKFg" Bounds="488,1581">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="OLpERXi3FWTNM3Uk5pHjJm" Ids="VFZzTsbHxeBOE9Q9aCyEXi,HPnvVkQI8mlOfW9JdkBdY6" />
             <Link Id="J1OvVapWBYbOpIjbi5sJ2T" Ids="ATWzF8ZUYf3LSWb1ZwyKqM,Ni7aLKZmjQAL6vvF7WXKFg" />
             <Node Bounds="408,1638,83,19" Id="VUn3v33KzYnPL93LCVi8zs">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10740,12 +10762,12 @@
               <Pin Id="H9tWt1GAtO2Oop7iyBGoWG" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="FrWSSPM3uxPMOlUqXbNlW0" Comment="" Bounds="488,1622,35,15" ShowValueBox="true" isIOBox="true" Value="ffff">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="QPDU7h2iF2qLvSYgU4deRO" Bounds="488,1676">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector4" />
               </p:TypeAnnotation>
             </Pad>
@@ -10761,7 +10783,7 @@
             <Link Id="Io0bR6wOHtzMgVHy9wCa0P" Ids="KyvESv8ZBXWQWHPNboZOn7,J5WqXGP4lSvNoNbUK8TyTH" />
             <Link Id="Ilw0XtMD8jOQOYVDnKUlug" Ids="AYGkJy1dmiKQacIwLBosaW,AMzg7c6PZGBQRo0QNAChrL" />
             <Node Bounds="408,1833,83,19" Id="Ns1IBtNSREuQUbJJj57obd">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10775,12 +10797,12 @@
               <Pin Id="GePhPmjh4f4O3BJRrB3uie" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="I5CWlEl2h7fPi2x0ybJvwp" Comment="" Bounds="488,1819,35,15" ShowValueBox="true" isIOBox="true" Value="h">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="Nna8So7G2B3MVp1GZjC1g0" Bounds="488,1870">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Integer64" />
               </p:TypeAnnotation>
             </Pad>
@@ -10793,13 +10815,13 @@
             <Link Id="DSHnF8Oy1DxMJCvb4MXEIH" Ids="LVVqff3wXhWP33969kIIMa,OSWY7YYbQr6P5slixwFqce" />
             <Link Id="BO0zYnVwdq9NvSnO1GAtpw" Ids="MfIJb8Tt49VM90XU7mQGYn,AMe0s7JTQajLppLsmH4zl2" />
             <Pad Id="VTRtKzAhIfSOwoUPkKXa9u" Comment="" Bounds="488,1319,20,15" ShowValueBox="true" isIOBox="true" Value="d">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ImmutableTypeFlag" Name="String" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="408,1333,83,19" Id="MNENNXQSxh8OreaX6yVygP">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10813,7 +10835,7 @@
               <Pin Id="EQW8oHDHEZPMivqALSvRz4" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="BZ5MiTerJGIMQuVruoG64Z" Bounds="488,1368">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Float64" />
               </p:TypeAnnotation>
             </Pad>
@@ -10826,7 +10848,7 @@
             <Link Id="NAqDO6yKtALNkODghHxeRN" Ids="HlO9nyE1Ja4PimbSbSXQUK,QVZg7jDgaZ9QaUVpkMHJth" />
             <Link Id="EGW7XmfiWvmOOgjIVIXFoZ" Ids="HHhu86sopBtQP0pV6oBRXv,HfZSbbjibN7LeNr6nd7njv" />
             <Node Bounds="408,2003,83,19" Id="JqxcPCH72aEMN6pb4cEq9Y">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10840,13 +10862,13 @@
               <Pin Id="RC2WfJBKh7bNL274zOPb9e" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="Mo1sjTNL5rnMRH42P2Md8Q" Bounds="488,2042">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="EICRJRkkj9zQatzSbPLKt7" Ids="RC2WfJBKh7bNL274zOPb9e,Mo1sjTNL5rnMRH42P2Md8Q" />
             <Node Bounds="408,2086,83,19" Id="P4fEl4dWfF9OZLcM4Sq1u7">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10860,13 +10882,13 @@
               <Pin Id="O32pWXuQ75MMXKDq1dE525" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="MZ9ceQMYX3UMtfZ0YYlL0A" Bounds="488,2125">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Char" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="H8Ec0ag3E6gOvvBbQdRqcP" Ids="O32pWXuQ75MMXKDq1dE525,MZ9ceQMYX3UMtfZ0YYlL0A" />
             <Node Bounds="408,2169,83,19" Id="B2VKNcM32ftMnfJESOuRGy">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10880,13 +10902,13 @@
               <Pin Id="FR6PsV5kHcWMs8tBQyyDxO" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="GxJoW32RxpZMN8mwAH3ssk" Bounds="488,2208">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="F2ZwehHHOGHNwHLiP3dAci" Ids="FR6PsV5kHcWMs8tBQyyDxO,GxJoW32RxpZMN8mwAH3ssk" />
             <Node Bounds="408,2346,83,19" Id="HuhJiRK2xwZMprRAAQsV6Z">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10900,7 +10922,7 @@
               <Pin Id="QPxpZks9ClvK92oGPqktEa" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="KLyEfcwblmcQXnCd4joZOL" Bounds="488,2385">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
                   <TypeReference>
@@ -10921,31 +10943,31 @@
             <Link Id="RAbnjEhIrIVOCHJ3nqgUwp" Ids="PeSImtJpvq1N6nj5VRoufd,SjIaj9FloeWPSQAdVmFSX5" />
             <Link Id="NmGZAmtBUB5NVPMWWv1S5e" Ids="V4MrupcqU8YLHriC1FEMWe,EKP1s30VWTiO2Nb6KqGe9T" />
             <Pad Id="PAZWO2QWyrENvUPVw1mvkO" Comment="" Bounds="488,1982,35,15" ShowValueBox="true" isIOBox="true" Value="s">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="RWUNB8KGTVxLbEzlfx8ONr" Ids="PAZWO2QWyrENvUPVw1mvkO,OBX2VFyiu9UOyzCRhjW2N7" />
             <Pad Id="HXZ52AqEdJsOINaft10O9W" Comment="" Bounds="488,2068,35,15" ShowValueBox="true" isIOBox="true" Value="c">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="VMJlhXINQ6FLuHNb072AHw" Ids="HXZ52AqEdJsOINaft10O9W,F0po6Gq8PGUPLA7PPIVdaX" />
             <Pad Id="Vm8fFPnD62XNzpFad4PlPz" Comment="" Bounds="488,2152,35,15" ShowValueBox="true" isIOBox="true" Value="F">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="Ky5kiyXQK1gLgYMYlv0WGx" Ids="Vm8fFPnD62XNzpFad4PlPz,TcreX4FK8W9OslEVM1LhBW" />
             <Pad Id="CVWQc6lmTx4MRwIHeCG2qL" Comment="" Bounds="488,2329,35,15" ShowValueBox="true" isIOBox="true" Value="b">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
             <Link Id="Ncgv5QVdQcUPum8Z5Mt5Y9" Ids="CVWQc6lmTx4MRwIHeCG2qL,Mjvxe1Vt4lrPdwiza0UnUF" />
             <Node Bounds="408,2251,83,19" Id="BCout0goxtcLndNk0rcsE8">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="TypeTagParser" />
               </p:NodeReference>
@@ -10959,12 +10981,12 @@
               <Pin Id="Kciy93Vuha1PCVpWPjFmOP" Name="Type" Kind="OutputPin" />
             </Node>
             <Pad Id="DrIpZEq8SYwQFawX6jFtYF" Bounds="488,2290">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="UqVTXOO9TWuNt8azANydT1" Comment="" Bounds="488,2234,35,15" ShowValueBox="true" isIOBox="true" Value="T">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
@@ -10979,7 +11001,7 @@
             <Pin Id="KCWvW6gDzYGQRd4o7Ejfhs" Name="TypeTags" Kind="InputPin" Bounds="1160,709" />
             <Pin Id="QcvLVUhDP9ULYIfhok9kT4" Name="Data" Kind="InputPin" Bounds="1172,728" />
             <Pin Id="HhGRpbntTruQFMS2VcyhxM" Name="Output" Kind="OutputPin" Bounds="1091,906">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Object" />
               </p:TypeAnnotation>
             </Pin>
@@ -10991,13 +11013,13 @@
 
 -->
         <Node Name="TypeTagParser (Internal)" Bounds="634,1215,222,250" Id="DRgxSJmRVBDQZWpuhG3Rni">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
             <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
           </p:NodeReference>
           <Patch Id="Ab29yUKlMZOPpRJdBctxDR" IsGeneric="true" ExplicitTypeParameters="T" ManuallySortedPins="true">
             <Node Bounds="665,1272,25,19" Id="Fiel9pr55HxM1BwdtJXyiM">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="=" />
               </p:NodeReference>
@@ -11006,7 +11028,7 @@
               <Pin Id="RGIWP23ohXILtuUV9MU2mN" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="703,1318,102,114" Id="R5sT2KW4v6lLGJAjoPcjNV">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -11016,7 +11038,7 @@
                 <Patch Id="FbdffRtVFYaPOX0TzC3CsH" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="CUqBJcGDXBjP8Y1zKj27Fl" Name="Then" ManuallySortedPins="true" />
                 <Node Bounds="717,1352,70,19" Id="OfqEgDYZCDoOpenzLQnWHU">
-                  <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                  <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="DataToArgs" />
                     <CategoryReference Kind="Category" Name="OSC" NeedsToBeDirectParent="true" />
@@ -11031,7 +11053,7 @@
                 </Node>
               </Patch>
               <ControlPoint Id="BIrGT24tIpeOiSrjSZs4no" Bounds="717,1325" Name="" Alignment="Top">
-                <p:TypeAnnotation>
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Object" />
                 </p:TypeAnnotation>
               </ControlPoint>
@@ -11073,7 +11095,7 @@
             <Pin Id="I0vfilf5Y7RMaRZcGswCaz" Name="Object Passthrough" Kind="InputPin" Bounds="844,1360" />
             <Pin Id="AqtjIDEL7usOdIyH46Js7q" Name="Data" Kind="InputPin" Bounds="869,1380" />
             <Pin Id="MEgQA5dRNYeLQ60QkwBGEc" Name="TypeTag" Kind="InputPin" Bounds="873,1328">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pin>
@@ -11103,14 +11125,14 @@
 
 -->
       <Node Name="OSCReceiver (Empty)" Bounds="433,330" Id="LnzLcAjeWNJMJ7nV6jWaiA" Summary="Receives messages without arguments from the specified OSC address" Remarks="Connect to an OSCServer">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="RP4omobJr4iPmSnz6NhBbc" IsGeneric="true">
           <Canvas Id="U0jQydp9aqoNqkUkr5YO60" CanvasType="Group">
             <ControlPoint Id="OMZb3glGSjrOMPyz1PwI60" Bounds="502,260" />
             <Node Bounds="445,287,73,19" Id="T07cPjJZcPIPDwsRJYXTB1">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="OSCReceiver" />
               </p:NodeReference>
@@ -11124,7 +11146,7 @@
             </Node>
             <ControlPoint Id="AOu83glnFNuNFTMYM0cVu3" Bounds="492,343" />
             <Pad Id="DAUiM9M8IDnNtOAJJiKlKn" Comment="" Bounds="428,341,35,17" ShowValueBox="true" isIOBox="true">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
                   <TypeReference>
@@ -11158,7 +11180,7 @@
           <Patch Id="C2ZvpASCmo1PCqbEV32R3M" Name="Create" />
           <Patch Id="TG9AsIrgEWuNHlQNzUkbsv" Name="Update">
             <Pin Id="ThwAMMHQFHMO9QyFUYi3Kf" Name="Input" Kind="InputPin" Bounds="448,271">
-              <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -11176,7 +11198,7 @@
 
 -->
       <Node Name="OSCReceiver" Bounds="434,275" Id="SfJDk17Od8wMmTO3AiRe99" Summary="Receives the arguments from the specified OSC address" Remarks="Connect to an OSCServer">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="Jh0Yfj010WuQYPH2WjE5rl" IsGeneric="true">
@@ -11185,7 +11207,7 @@
             <ControlPoint Id="UVySMFauIfPMQzXOqRFvNk" Bounds="470,351" />
             <ControlPoint Id="BoJc6ioGFv7LF2q4rOks3u" Bounds="407,351" />
             <Node Bounds="351,483,65,19" Id="ESPqwC1umhTNAiYL1Xfcmu">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -11198,7 +11220,7 @@
             <ControlPoint Id="JQMJW0Kioz7NhM0JLeeUaS" Bounds="353,351" />
             <ControlPoint Id="QPAWcDR1GdaQE9acaZeUFn" Bounds="406,429" />
             <Node Bounds="351,382,112,19" Id="Fs3WiWTrRzRLTet8AvS2ik">
-              <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+              <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="OSCReceiver (Reactive)" />
               </p:NodeReference>
@@ -11233,7 +11255,7 @@
           <Patch Id="RhcbHcHlgPbNKIL8kY13qO" Name="Create" />
           <Patch Id="ApEtAdff4z7QalhHYhrPe3" Name="Update">
             <Pin Id="QJxC4B7W4COLItCFzplfTb" Name="Input" Kind="InputPin" Bounds="377,288">
-              <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -11252,13 +11274,13 @@
 
 -->
       <Node Name="OSCReceiver (Object)" Bounds="435,376" Id="AKfBQM1rHROOSkC4eccZoy">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="MbEEhiEMgk0NzFLfEXHkBI" IsGeneric="true">
           <Canvas Id="Raf3PM6am6OMCzxtqoZ6rN" CanvasType="Group">
             <Node Bounds="290,289,240,254" Id="LfF2DiZA6NrLddXEAuEbz5">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ProcessAppFlag" Name="ForEach" />
                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -11275,7 +11297,7 @@
                 <ControlPoint Id="BqXD9ZOfHwHOebIbdj1rQq" Bounds="358,297" />
                 <ControlPoint Id="QSRE0xZPckgQcxspTWHJPG" Bounds="439,536" />
                 <Node Bounds="342,322,176,186" Id="Ey8BNGhFc5iMglyLA5Q92l">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -11289,7 +11311,7 @@
                     <Patch Id="UgCEbYV1c7gQSFQYV3jHJd" Name="Update" ManuallySortedPins="true" />
                     <Patch Id="Oi6tmVQU6fbPeFLbLL9BU9" Name="Dispose" ManuallySortedPins="true" />
                     <Node Bounds="354,349,62,26" Id="LsDJHhwQ9oFPmAQkKSaPvN">
-                      <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastSymbolSource="VL.IO.OSC.vl">
+                      <p:NodeReference LastCategoryFullName="IO.OSC.OSCMessage" LastDependency="VL.IO.OSC.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="RecordType" Name="OSCMessage" />
                         <Choice Kind="OperationCallFlag" Name="Split" />
@@ -11300,7 +11322,7 @@
                       <Pin Id="QITPPfcZHsnPeSfEjcsrDZ" Name="Arguments" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="399,402,87,19" Id="OjfAvMMn3GzLGmroZXSJsB">
-                      <p:NodeReference LastCategoryFullName="IO.OSC" LastSymbolSource="VL.IO.OSC.vl">
+                      <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="ParseByTypetag" />
                       </p:NodeReference>
@@ -11309,7 +11331,7 @@
                       <Pin Id="TVe7UamRPEAL0ao9Fkjgwh" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="354,403,38,19" Id="Bs2mFPy0BFyM2gDMA9mKSN">
-                      <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Trim (Char)" />
                       </p:NodeReference>
@@ -11318,7 +11340,7 @@
                       <Pin Id="NBGt6x4ehy3LV4MIMATw8f" Name="Output" Kind="StateOutputPin" />
                     </Node>
                     <Node Bounds="445,449,61,19" Id="Dvd9PAS7xc5N0eS5BtTpms">
-                      <p:NodeReference LastCategoryFullName="System.Reflection.IVLObject" LastSymbolSource="System.Reflection.vl">
+                      <p:NodeReference LastCategoryFullName="System.Reflection.IVLObject" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="WithValue" />
                         <CategoryReference Kind="MutableInterfaceType" Name="IVLObject" NeedsToBeDirectParent="true" />
@@ -11336,7 +11358,7 @@
             <ControlPoint Id="IUWrIKFrc4MOm4jPk2nlOC" Bounds="438,262" />
             <ControlPoint Id="JS8fegc9t0rLPQq1Y5NLiW" Bounds="289,647" />
             <Node Bounds="291,581,65,19" Id="BRvRMSl1Yg5PweCu1IW7sb">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
@@ -11373,7 +11395,7 @@
           <Patch Id="R0n1DSuM79SLpYB36DtFF8" Name="Create" />
           <Patch Id="COQtID4YQRMPhQnjeHwztK" Name="Update">
             <Pin Id="EKRvdX1f42XOoMdUOzLn1C" Name="Input" Kind="InputPin" Bounds="297,95">
-              <p:TypeAnnotation LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <p:TypeAnnotation LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Observable" />
               </p:TypeAnnotation>
             </Pin>
@@ -11408,6 +11430,5 @@
   </Patch>
   <NugetDependency Id="BRI1by1CrieP2IbgZKHuqq" Location="VL.Skia" Version="2021.4.12" />
   <NugetDependency Id="Tj9pR4jK7PdLUvUwsqAtdc" Location="VL.Core" Version="2021.4.12" />
-  <NugetDependency Id="BN7vxCsXiyZLLmCMsmdAAt" Location="VL.Lang" Version="2021.4.12" />
   <PlatformDependency Id="Jv9kUW4hHexQYv8tqnP27D" Location="./lib/netstandard2.0/VL.IO.OSC.dll" />
 </Document>


### PR DESCRIPTION
Added a detection to the `Listening IP` input if it's an [Multicast IP](https://en.wikipedia.org/wiki/IP_multicast) and provides it to the corresponding Inputs of the UDP Server.

(Left Current, Right new)<img width="797" alt="image" src="https://user-images.githubusercontent.com/948771/223696473-43c85ee8-7271-45b8-981d-01d1e7c0fe7f.png">

With that addition you can send OSC Messages to multiple instances of a patch or to multiple devices. The sending device only needs to send the message once. This is good for Backup scenarios, or if you have a sending device which only supports one receiver, but you need messages on multiple instances.